### PR TITLE
Envjs fix -- shared instance of styleIndex on all CSS2Property objects

### DIFF
--- a/ext/env.rhino.1.2.js
+++ b/ext/env.rhino.1.2.js
@@ -10869,7 +10869,7 @@ var __toDashed__ = function(camelCaseName) {
 
 CSS2Properties = function(element){
     //console.log('css2properties %s', __cssproperties__++);
-    this.styleIndex = __supportedStyles__;//non-standard
+    this.styleIndex = __extend__({}, __supportedStyles__);//non-standard
     this.type = element.tagName;//non-standard
     __setArray__(this, []);
     __cssTextToStyles__(this, element.cssText || '');


### PR DESCRIPTION
There is a bug in the included version of env.js which causes all instances of CSS2Properties to share a common this.styleIndex object. This makes testing style properties on DOM elements problematic at best.

To see the problem, do the following before applying the patch.
    $ java -jar js.jar
    load("env.rhino.1.2.js");
    a = document.createElement("div");
    b = document.createElement("div");
    a.style.top = "5px";
    b.style.top; // returns "5px"
