### PR TITLE
Make tree style logging work

### DIFF
--- a/src/jasmine.console_reporter.js
+++ b/src/jasmine.console_reporter.js
@@ -1,9 +1,8 @@
 (function() {
-    
     if (! jasmine) {
         throw new Exception("jasmine library does not exist in global namespace!");
     }
-    
+
     /**
      * Basic reporter that outputs spec results to the browser console.
      * Useful if you need to test an html page and don't want the TrivialReporter
@@ -18,47 +17,59 @@
         this.started = false;
         this.finished = false;
     };
-    
+
     ConsoleReporter.prototype = {
         reportRunnerResults: function(runner) {
-            this.finished = true;
-            this.log("Runner Finished.");
-        },
-
-        reportRunnerStarting: function(runner) {
-            this.started = true;
-            this.log("Runner Started.");
-        },
-
-        reportSpecResults: function(spec) {
-            var resultText = "Failed.";
-            
-            if (spec.results().passed()) {
-                resultText = "Passed.";
+            if (this.hasConsole()) {
+                this.reportToConsole(runner.suites());
             }
-            
-            this.log(resultText);
+            this.finished = true;
         },
 
-        reportSpecStarting: function(spec) {
-            this.log(spec.suite.description + ' : ' + spec.description + ' ... ');
+        hasConsole: function() {
+            return window['console'] && console['info'] && console['warn'] && console['group'] && console['groupEnd'] && console['groupCollapsed'];
         },
 
-        reportSuiteResults: function(suite) {
-            var results = suite.results();
-            
-            this.log(suite.description + ": " + results.passedCount + " of " + results.totalCount + " passed.");
-        },
-        
-        log: function(str) {
-            var console = jasmine.getGlobal().console;
-            
-            if (console && console.log) {
-                console.log(str);
+        reportToConsole: function (suites) {
+            for (var i in suites) {
+                suiteResults(suites[i]);
             }
         }
     };
-    
+
+    function suiteResults(suite) {
+        console.group(suite.description);
+        var specs = suite.specs();
+        for (var j in specs) {
+            specResults(specs[j]);
+        }
+        console.groupEnd();
+    }
+
+    function specResults(spec) {
+        var results = spec.results();
+        if (results.passed() && console.groupCollapsed) {
+            console.groupCollapsed(spec.description);
+        } else {
+            console.group(spec.description);
+        }
+        var items = results.getItems();
+        for (var k in items) {
+            itemResults(items[k]);
+        }
+        console.groupEnd();
+    }
+
+    function itemResults(item) {
+        if (item.passed && !item.passed()) {
+            console.warn({actual:item.actual,expected: item.expected});
+            item.trace.message = item.matcherName;
+            console.error(item.trace);
+        } else {
+            console.info('Passed');
+        }
+    }
+
     // export public
     jasmine.ConsoleReporter = ConsoleReporter;
 })();


### PR DESCRIPTION
I modified the ConsoleLogger:
- Results are shown in tree style fashion using console.group and groupEnd functions
- Failed tests are displayed with their navigable stack traces
- Failed tests are expanded and passed tests collapsed by default
- console.info is used for passed assertions and console.warn and console.error for failed tests

Tested with latest Firefox
