### PR TITLE
Added a package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "author": "Larry Myers",
+  "name": "jasmine-reporters",
+  "description": "Reporters for the Jasmine BDD Framework",
+  "version": "0.1.0",
+  "homepage": "https://github.com/larrymyers/jasmine-reporters",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/larrymyers/jasmine-reporters.git"
+  },
+  "main" : "./src/load_reporters.js",
+  "engines": {
+    "node": "~v0.4.11"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/src/load_reporters.js
+++ b/src/load_reporters.js
@@ -1,0 +1,2 @@
+require("./jasmine.console_reporter.js")
+require("./jasmine.junit_reporter.js")


### PR DESCRIPTION
I added a package.json file and a main file that require the reporters automatically.

With the package.json file the project can be published as a nodejs module than it could be used as a dependencies by jasmine-node so that we dont need to include the junit reporter file directly inside the other project.

If this is accepted could you review the information inside the json file? im not exactly sure if the values are right. Especially the version number.

Cheers!
