### PR TITLE
Improve tree style console reporting

### DIFF
--- a/src/jasmine.console_reporter.js
+++ b/src/jasmine.console_reporter.js
@@ -22,11 +22,13 @@
         reportRunnerResults: function(runner) {
             if (this.hasGroupedConsole()) {
                 var suites = runner.suites();
+                startGroup(runner.results(), 'tests')
                 for (var i in suites) {
                     if (!suites[i].parentSuite) {
                         suiteResults(suites[i]);
                     }
                 }
+                console.groupEnd()
             }
             else {
                 var dur = (new Date()).getTime() - this.start_time;
@@ -91,7 +93,8 @@
     };
 
     function suiteResults(suite) {
-        console.group(suite.description);
+        var results = suite.results();
+        startGroup(results, suite.description);
         var specs = suite.specs();
         for (var i in specs) {
             specResults(specs[i]);
@@ -105,11 +108,7 @@
 
     function specResults(spec) {
         var results = spec.results();
-        if (results.passed() && console.groupCollapsed) {
-            console.groupCollapsed(spec.description);
-        } else {
-            console.group(spec.description);
-        }
+        startGroup(results, spec.description)
         var items = results.getItems();
         for (var k in items) {
             itemResults(items[k]);
@@ -125,6 +124,11 @@
         } else {
             console.info('Passed');
         }
+    }
+
+    function startGroup(results, description) {
+        var consoleFunc = (results.passed() && console.groupCollapsed) ? 'groupCollapsed' : 'group';
+        console[consoleFunc](description + ' (' + results.passedCount + '/' + results.totalCount + ' passed, ' + results.failedCount + ' failures)');
     }
 
     // export public


### PR DESCRIPTION
Display test summary in titles, collapse tree when all tests are passed, wrap all suites in one group.
