### PR TITLE
Correct suite array iteration

### DIFF
--- a/src/jasmine.console_reporter.js
+++ b/src/jasmine.console_reporter.js
@@ -23,7 +23,7 @@
             if (this.hasGroupedConsole()) {
                 var suites = runner.suites();
                 startGroup(runner.results(), 'tests');
-                for (var i in suites) {
+                for (var i=0; i<suites.length; i++) {
                     if (!suites[i].parentSuite) {
                         suiteResults(suites[i]);
                     }


### PR DESCRIPTION
The "suites" array is currently iterated via the "for p in x" syntax. This does not work when custom methods are added to Array's prototype.
