### PR TITLE
Corrected the check for the existence of jasmine

### DIFF
--- a/src/jasmine.junit_reporter.js
+++ b/src/jasmine.junit_reporter.js
@@ -1,7 +1,7 @@
 (function() {
 
-    if (! jasmine) {
-        throw new Exception("jasmine library does not exist in global namespace!");
+    if (typeof jasmine == 'undefined') {
+        throw new Error("jasmine library does not exist in global namespace!");
     }
 
     function elapsed(startTime, endTime) {


### PR DESCRIPTION
- The check `if(! jasmine)` throws a [ReferenceError](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/ReferenceError)
- Javascript doesn't have an `Exception` object, instead it has an [Error](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Error) object
