### PR TITLE
TAP: don't report skipped tests

### DIFF
--- a/src/jasmine.tap_reporter.js
+++ b/src/jasmine.tap_reporter.js
@@ -42,6 +42,9 @@
             var errorMessage = '';
 
             var results = spec.results();
+            if (results.skipped) {
+                return;
+            }
             var passed = results.passed();
 
             this.passed_asserts += results.passedCount;


### PR DESCRIPTION
Currently, skipped tests are included in the output, messing it up. This fixes that problem.
