### PR TITLE
junit reporter should report skipped tests

### DIFF
--- a/src/jasmine.junit_reporter.js
+++ b/src/jasmine.junit_reporter.js
@@ -65,6 +65,9 @@
             spec.duration = elapsed(spec.startTime, new Date());
             spec.output = '<testcase classname="' + this.getFullName(spec.suite) +
                 '" name="' + escapeInvalidXmlChars(spec.description) + '" time="' + spec.duration + '">';
+            if(results.skipped) {
+              spec.output = spec.output + "<skipped />";
+            }
 
             var failure = "";
             var failures = 0;


### PR DESCRIPTION
Hi,

this change will report skipped tests in the created XML so that they are recognized (at least by the Eclipse IDE) when showing the test cases.

Br Alexander.
![skipped_tests](https://f.cloud.github.com/assets/3957921/405694/98612b38-aa00-11e2-9017-43aa8ef20d9e.png)
