### PR TITLE
Don't count skipped spec what filtered by specFilter.

### DIFF
--- a/src/jasmine.terminal_reporter.js
+++ b/src/jasmine.terminal_reporter.js
@@ -70,6 +70,10 @@
         reportSpecResults: function(spec) {
             var color = "red";
 
+            if (spec.results().skipped) {
+                return;
+            }
+
             if (spec.results().passed()) {
                 this.passed_specs++;
                 color = "green";


### PR DESCRIPTION
Fixed following problem.

Output incorrect failure count if test page contain filtered specs by `jasmine.getEnv().specFilter`.
