### PR TITLE
Change method to output text to stdout without line break.

### DIFF
--- a/test/phantomjs-testrunner.js
+++ b/test/phantomjs-testrunner.js
@@ -66,9 +66,8 @@ else {
 function logAndWorkAroundDefaultLineBreaking(msg) {
     var interpretAsWithoutNewline = /(^(\033\[\d+m)*[\.F](\033\[\d+m)*$)|( \.\.\.$)/;
     if (navigator.userAgent.indexOf("Windows") < 0 && interpretAsWithoutNewline.test(msg)) {
-        var fs = require('fs');
-        // system.stdout.write(msg) ? wait for http://code.google.com/p/phantomjs/issues/detail?id=243 to be implemented
-        fs.write('/dev/stdout', msg, 'w');
+        var system = require('system');
+        system.stdout.write(msg);
     } else {
         console.log(msg);
     }


### PR DESCRIPTION
PhantomJS 1.9.0 implement direct access to stdout via system module.

https://github.com/ariya/phantomjs/issues/10243
(original: http://code.google.com/p/phantomjs/issues/detail?id=243 )

Additional information:
original `fs.write` logic cause error when phantomjs-testrunner.js is launched by grunt-exec task.
