### PR TITLE
Modify logic to watch a finish of spec.

### DIFF
--- a/src/jasmine.junit_reporter.js
+++ b/src/jasmine.junit_reporter.js
@@ -48,9 +48,15 @@
         this.consolidate = consolidate === jasmine.undefined ? true : consolidate;
         this.useDotNotation = useDotNotation === jasmine.undefined ? true : useDotNotation;
     };
+    JUnitXmlReporter.started_at = null; // will be updated when test runner start
     JUnitXmlReporter.finished_at = null; // will be updated after all files have been written
 
     JUnitXmlReporter.prototype = {
+        reportRunnerStarting: function() {
+            // When run test, make it known on JUnitXmlReporter
+            JUnitXmlReporter.started_at = (new Date()).getTime();
+        },
+
         reportSpecStarting: function(spec) {
             spec.startTime = new Date();
 

--- a/test/phantomjs-testrunner.js
+++ b/test/phantomjs-testrunner.js
@@ -156,7 +156,7 @@ function processPage(status, page, resultsKey) {
         var isFinished = function() {
             return page.evaluate(function(){
                 // if there's a JUnitXmlReporter, return a boolean indicating if it is finished
-                if (jasmine.JUnitXmlReporter) {
+                if (jasmine.JUnitXmlReporter && jasmine.JUnitXmlReporter.started_at !== null) {
                     return jasmine.JUnitXmlReporter.finished_at !== null;
                 }
                 // otherwise, see if there is anything in a "finished-at" element


### PR DESCRIPTION
#### Problem:

My test page load some javascript files of reporter include `jasmine.junit_reporter.js`, but use other reporter only if set some flag.
If test page doesn't use `JUnitXmlReporter`, check logic doesn't work correctly to finish test runner.
#### Fix:

Add `JUnitXmlReporter.started_at` to check running state of `JUnitXmlReporter`.
