### PR TITLE
TeamCity Progress Start and Finish

### DIFF
--- a/src/jasmine.teamcity_reporter.js
+++ b/src/jasmine.teamcity_reporter.js
@@ -17,9 +17,13 @@
     };
 
     TeamcityReporter.prototype = {
-        reportRunnerResults: function(runner) { },
+        reportRunnerResults: function(runner) {
+            this.log("##teamcity[progressFinish 'Running Jasmine Tests']");
+        },
 
-        reportRunnerStarting: function(runner) { },
+        reportRunnerStarting: function(runner) {
+            this.log("##teamcity[progressStart 'Running Jasmine Tests']");
+        },
 
         reportSpecResults: function(spec) { },
 


### PR DESCRIPTION
TeamCity has two additional comment log entries to indicate when the entire suite of tests is starting or ended. Adding these two commands will allow other tools to monitor the Jasmine tests, and identify when they have completely finished.
