### PR TITLE
update phantomjs-testrunner.js for backwards compat

### DIFF
--- a/test/phantomjs-testrunner.js
+++ b/test/phantomjs-testrunner.js
@@ -66,8 +66,13 @@ else {
 function logAndWorkAroundDefaultLineBreaking(msg) {
     var interpretAsWithoutNewline = /(^(\033\[\d+m)*[\.F](\033\[\d+m)*$)|( \.\.\.$)/;
     if (navigator.userAgent.indexOf("Windows") < 0 && interpretAsWithoutNewline.test(msg)) {
-        var system = require('system');
-        system.stdout.write(msg);
+        try {
+            var system = require('system');
+            system.stdout.write(msg);
+        } catch (e) {
+            var fs = require('fs');
+            fs.write('/dev/stdout', msg, 'w');
+        }
     } else {
         console.log(msg);
     }


### PR DESCRIPTION
- Previous revision introduces system.stdout.write
- Older versions of PhantomJS (<1.9) still need to use fs.write
