### PR TITLE
Removed 'TEST-' prepend from the file name and repaired specs

### DIFF
--- a/src/jasmine.junit_reporter.js
+++ b/src/jasmine.junit_reporter.js
@@ -24,11 +24,11 @@
     }
 
     function escapeInvalidXmlChars(str) {
-        return str.replace(/\&/g, "&amp;")
-            .replace(/</g, "&lt;")
+        return str.replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;");
+            .replace(/\'/g, "&apos;")
+            .replace(/\&/g, "&amp;");
     }
 
     /**
@@ -42,11 +42,14 @@
      * @param {boolean} useDotNotation whether to separate suite names with
      *                  dots rather than spaces (ie "Class.init" not
      *                  "Class init"); default: true
+     * @param {string} filePrefix is the string value that is prepended to the
+     *                  xml output file; default: 'TEST-'
      */
-    var JUnitXmlReporter = function(savePath, consolidate, useDotNotation) {
+    var JUnitXmlReporter = function(savePath, consolidate, useDotNotation, filePrefix) {
         this.savePath = savePath || '';
         this.consolidate = consolidate === jasmine.undefined ? true : consolidate;
         this.useDotNotation = useDotNotation === jasmine.undefined ? true : useDotNotation;
+        this.filePrefix = filePrefix || 'TEST-';
     };
     JUnitXmlReporter.finished_at = null; // will be updated after all files have been written
 
@@ -120,7 +123,7 @@
             var suites = runner.suites();
             for (var i = 0; i < suites.length; i++) {
                 var suite = suites[i];
-                var fileName = this.getFullName(suite, true) + '.xml';
+                var fileName = this.filePrefix + this.getFullName(suite, true) + '.xml';
                 var output = '<?xml version="1.0" encoding="UTF-8" ?>';
                 // if we are consolidating, only write out top-level suites
                 if (this.consolidate && suite.parentSuite) {
@@ -204,9 +207,6 @@
             else {
                 fullName = suite.getFullName();
             }
-
-            // replace empty name with 'test'
-            fullName = fullName.replace(/^$/, "test");
 
             // Either remove or escape invalid XML characters
             if (isFilename) {

--- a/test/JUnitXmlReporterSpec.js
+++ b/test/JUnitXmlReporterSpec.js
@@ -48,6 +48,28 @@
             it("should default useDotNotation to true", function(){
                 expect(reporter.useDotNotation).toBe(true);
             });
+
+            describe("file prepend", function(){
+                it("should default output file prepend to \'TEST-\'", function () {
+                    expect(reporter.filePrefix).toBe("TEST-");
+                });
+                it("should allow the user to override the default xml output file prepend", function () {
+                    reporter = new jasmine.JUnitXmlReporter("", true, true, "alt-prepend-");
+                    expect(reporter.filePrefix).toBe("alt-prepend-");
+                });
+                it("should output the file with the modified prepend", function () {
+
+                    reporter = new jasmine.JUnitXmlReporter("", true, true, "alt-prepend-");
+
+                    spyOn(reporter, "writeFile");
+
+                    triggerSuiteEvents([suite]);
+
+                    reporter.reportRunnerResults(runner);
+
+                    expect(reporter.writeFile).toHaveBeenCalledWith(reporter.savePath, "alt-prepend-ParentSuite.xml", jasmine.any(String));
+                });
+            });
         });
 
         describe("reportSpecStarting", function(){
@@ -85,7 +107,7 @@
             });
 
             it("should escape bad xml characters in spec description", function() {
-                expect(spec.output).toContain("&amp; &lt; &gt; &quot; &apos;");
+                expect(spec.output).toContain("&amp; &amp;lt; &amp;gt; &amp;quot; &amp;apos;");
             });
 
             it("should generate valid xml <failure> output if test failed", function(){
@@ -109,7 +131,7 @@
 
                 expect(spec.output).toContain("<failure");
                 expect(spec.output).toContain("type=\"" + expectationResult.type + "\"");
-                expect(spec.output).toContain("message=\"Expected &apos;a&apos; to equal &apos;&amp;&apos;.\"");
+                expect(spec.output).toContain("message=\"Expected &amp;apos;a&amp;apos; to equal &amp;apos;&amp;&amp;apos;.\"");
                 expect(spec.output).toContain(">in test1.js:12\nin test2.js:123</failure>");
             });
         });
@@ -156,15 +178,10 @@
                     reporter.reportRunnerResults(runner);
                 });
                 it("should remove invalid filename chars from the filename", function() {
-                    expect(reporter.writeFile).toHaveBeenCalledWith(reporter.savePath, "SiblingSuiteWithInvalidChars.xml", jasmine.any(String));
+                    expect(reporter.writeFile).toHaveBeenCalledWith(reporter.savePath, "TEST-SiblingSuiteWithInvalidChars.xml", jasmine.any(String));
                 });
                 it("should remove invalid xml chars from the classname", function() {
-                    expect(siblingSuite.output).toContain("SiblingSuite With Invalid Chars &amp; &lt; &gt; &quot; &apos; | : \\ /");
-                });
-                it("should return a name of 'test' for empty files", function () {
-                  suite.description = '';
-                  expect(reporter.getFullName(suite)).toContain('test');
-                  expect(reporter.getFullName(suite, true)).toContain('test');
+                    expect(siblingSuite.output).toContain("SiblingSuite With Invalid Chars &amp; &amp;lt; &amp;gt; &amp;quot; &amp;apos; | : \\ /");
                 });
             });
 


### PR DESCRIPTION
Fixed the XML character escaping regex

Prepending 'TEST-' prevents users from having full control of the name of the output files.
The specs were failing because the ampersand regex was running on the previous replaces. So $lt; was becoming $amp;lt;. Moved the ampersand regex to the front.
