### PR TITLE
Show test name for failing test in terminal_reporter at verbosity 1

### DIFF
--- a/src/jasmine.terminal_reporter.js
+++ b/src/jasmine.terminal_reporter.js
@@ -98,6 +98,8 @@
                 if (this.verbosity === 2) {
                   this.log(" ");
                   this.log(this.indentWithCurrentLevel(this.indent_string + spec.getFullName()));
+                } else if (this.verbosity === 1) {
+                  this.log(spec.getFullName());
                 }
                 var items = spec.results().getItems()
                 for (var i = 0; i < items.length; i++) {


### PR DESCRIPTION
For the terminal reporter at verbosity 1 this change makes sure we also show the test name for failing tests (as we already show the failing expectation).

Before:

```
    Expected 2 to equal 3.
FAILURE: 3 specs, 1 failure in 0.004s.
```

Now

```
Basic Suite Should fail when it hits an inequal statement..
    Expected 2 to equal 3.
FAILURE: 3 specs, 1 failure in 0.004s.
```
