### PR TITLE
Don't escape ampersands in escapes

### DIFF
--- a/src/jasmine.junit_reporter.js
+++ b/src/jasmine.junit_reporter.js
@@ -24,11 +24,11 @@
     }
 
     function escapeInvalidXmlChars(str) {
-        return str.replace(/</g, "&lt;")
+        return str.replace(/\&/g, "&amp;")
+            .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;")
-            .replace(/\&/g, "&amp;");
+            .replace(/\'/g, "&apos;");
     }
 
     /**


### PR DESCRIPTION
Without this patch, ' is replaced with &apos; which is then further replaced with &amp;apos;