### PR TITLE
Fix log function which wasn't working in a node.js context.

### DIFF
--- a/src/tap_reporter.js
+++ b/src/tap_reporter.js
@@ -117,9 +117,9 @@
             exportObject.endTime = endTime;
         };
         function log(str) {
-            var console = global.console;
-            if (console && console.log) {
-                console.log(str);
+            var con = global.console || console;
+            if (con && con.log) {
+                con.log(str);
             }
         }
     };

--- a/src/teamcity_reporter.js
+++ b/src/teamcity_reporter.js
@@ -124,9 +124,9 @@
     };
 
     function log(str) {
-        var console = global.console;
-        if (console && console.log) {
-            console.log(str);
+        var con = global.console || console;
+        if (con && con.log) {
+            con.log(str);
         }
     }
     // shorthand for logging TeamCity messages

--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -195,9 +195,9 @@
             return new Array(level).join(indent_string) + string;
         }
         function log(str) {
-            var console = global.console;
-            if (console && console.log) {
-                console.log(str);
+            var con = global.console || console;
+            if (con && con.log) {
+                con.log(str);
             }
         }
         function inColor(string, color) {


### PR DESCRIPTION
I was trying to wire up `jasmine-node@2.0.0` to use your teamcity reporter however I noticed that even if it was added as a reporter it wasn't outputting anything to the console. Since `this` isn't the global object in node, it was getting confused in your log function.

This change fixes it. It likely isn't the only way to do it, so if you have any preferences, please feel free to let me know.
