### PR TITLE
Remove trailing 'Z' from timestamp in TeamCity reporter.

### DIFF
--- a/src/teamcity_reporter.js
+++ b/src/teamcity_reporter.js
@@ -28,8 +28,7 @@
             pad(d.getUTCMinutes()) + ':' +
             pad(d.getUTCSeconds()) + '.' +
             // TeamCity wants ss.SSS
-            padThree(d.getUTCMilliseconds()) +
-            'Z';
+            padThree(d.getUTCMilliseconds());
     }
     function log(str) {
         var con = global.console || console;


### PR DESCRIPTION
According to http://youtrack.jetbrains.com/issue/TW-36173 TeamCity doesn't fully support the ISO8601 spec. I've seen this to be the case with TeamCity 8.0.5. Removing the trailing 'Z' from the timestamp makes TC happy.
