### PR TITLE
Rename .html-reporter to .jasmine_html-reporter

### DIFF
--- a/bin/phantomjs-testrunner.js
+++ b/bin/phantomjs-testrunner.js
@@ -167,12 +167,18 @@ function processPage(status, page, resultsKey) {
                 }
                 // otherwise, scrape the DOM for the HtmlReporter "finished in ..." output
                 var durElem = document.querySelector(".html-reporter .duration");
+                if (!durElem) {
+                    durElem = document.querySelector(".jasmine_html-reporter .duration");
+                }
                 return durElem && durElem.textContent && durElem.textContent.toLowerCase().indexOf("finished in") === 0;
             });
         };
         var getResultsFromHtmlRunner = function() {
             return page.evaluate(function(){
                 var resultElem = document.querySelector(".html-reporter .alert .bar");
+                if (!resultElem) {
+                    resultElem = document.querySelector(".jasmine_html-reporter .alert .bar");
+                }
                 return resultElem && resultElem.textContent &&
                     resultElem.textContent.match(/(\d+) spec.* (\d+) failure.*/) ||
                    ["Unable to determine success or failure."];


### PR DESCRIPTION
According the jasmine `HtmlReporter.js` source code, the classname has been changed from `.html-reporter` to `.jasmine_html-reporter`

https://github.com/pivotal/jasmine/blob/master/src/html/HtmlReporter.js#L24
