### PR TITLE
Empty tag in jUnit report

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -277,21 +277,26 @@
             var xml = '\n  <testcase classname="' + getFullyQualifiedSuiteName(spec._suite) + '"';
             xml += ' name="' + escapeInvalidXmlChars(spec.description) + '"';
             xml += ' time="' + elapsed(spec._startTime, spec._endTime) + '"';
-            xml += '>';
 
+            var testCaseBody = '';
             if (isSkipped(spec) || isDisabled(spec)) {
-                xml += '<skipped />';
+                testCaseBody = '<skipped />';
             } else if (isFailed(spec)) {
                 for (var i = 0, failure; i < spec.failedExpectations.length; i++) {
                     failure = spec.failedExpectations[i];
-                    xml += '\n   <failure type="' + (failure.matcherName || "exception") + '"';
-                    xml += ' message="' + trim(escapeInvalidXmlChars(failure.message))+ '"';
-                    xml += '>';
-                    xml += '<![CDATA[' + trim(failure.stack || failure.message) + ']]>';
-                    xml += '\n   </failure>';
+                    testCaseBody += '\n   <failure type="' + (failure.matcherName || "exception") + '"';
+                    testCaseBody += ' message="' + trim(escapeInvalidXmlChars(failure.message))+ '"';
+                    testCaseBody += '>';
+                    testCaseBody += '<![CDATA[' + trim(failure.stack || failure.message) + ']]>';
+                    testCaseBody += '\n   </failure>';
                 }
             }
-            xml += '\n  </testcase>';
+
+            if (testCaseBody) {
+                xml += '>' + testCaseBody + '\n  </testcase>';
+            } else {
+                xml += ' />'
+            }
             return xml;
         }
 


### PR DESCRIPTION
Hi

Little update in junit_reporter.js
Use XML empty tag syntax for empty "testcase" tags. It seems to me that this looks better.