### PR TITLE
Fix for over-escaping invalid XML characters

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -32,11 +32,11 @@
             pad(d.getSeconds());
     }
     function escapeInvalidXmlChars(str) {
-        return str.replace(/</g, "&lt;")
+        return str.replace(/\&/g, "&amp;")
+            .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;")
-            .replace(/\&/g, "&amp;");
+            .replace(/\'/g, "&apos;");
     }
     function getQualifiedFilename(path, filename, separator) {
         if (path && path.substr(-1) !== separator && filename.substr(0) !== separator) {


### PR DESCRIPTION
My first pull request ever, so bear with me if I'm doing something wrong...

In the original version, a failure text like:    
<pre>&lt;Expected ' ' to be 'some text' &gt;</pre>

is written like this into the XML file:           
<pre>&lt;Expected &amp;amp;apos;&amp;amp;apos; to be &amp;amp;apos;some text&amp;amp;apos;&gt;</pre>

Correct would be:     
<pre>&lt;Expected &amp;apos;&amp;apos; to be &amp;apos;some text&amp;apos;&gt;</pre>

The problem is that the '&' gets replaced after all other replacments have taken place.
This way it is escaping the '&' part of the valid XML notation.
