### PR TITLE
Added package parameter for JUnit-Reporter

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -79,6 +79,7 @@
      *   xml output file (default: junitresults-)
      *   NOTE: if consolidateAll is true, the default is simply "junitresults" and
      *     this becomes the actual filename, ie "junitresults.xml"
+     * @param {string} [package] is the base package for all test suits that are handled by this report {default: ''}
      */
     exportObject.JUnitXmlReporter = function(options) {
         var self = this;

--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -91,6 +91,7 @@
         self.consolidateAll = self.consolidate !== false && (options.consolidateAll === UNDEFINED ? true : options.consolidateAll);
         self.useDotNotation = options.useDotNotation === UNDEFINED ? true : options.useDotNotation;
         self.filePrefix = options.filePrefix || (self.consolidateAll ? 'junitresults' : 'junitresults-');
+        self.package = options.package === UNDEFINED ? '' : options.package;
 
         var suites = [],
             currentSuite = null,
@@ -279,6 +280,7 @@
             xml += ' disabled="' + suite._disabled + '"';
             // Because of JUnit's flat structure, only include directly failed tests (not failures for nested suites)
             xml += ' failures="' + suite._failures + '"';
+            xml += ' package="' + self.package + '"';
             xml += '>';
 
             for (var i = 0; i < suite._specs.length; i++) {

--- a/test/JUnitXmlReporterSpec.js
+++ b/test/JUnitXmlReporterSpec.js
@@ -110,6 +110,18 @@
                     expect(reporter.writeFile).toHaveBeenCalledWith("alt-prefix-ParentSuite.xml", jasmine.any(String));
                 });
             });
+
+            describe("package", function() {
+                it("should default output package to be empty", function () {
+                    expect(reporter.package).toBe("");
+                });
+                it("should output package to be the same as the parameter", function () {
+                    setupReporterWithOptions({
+                        package: "testpackage"
+                    });
+                    expect(reporter.package).toBe("testpackage");
+                });
+                })
         });
 
         describe("generated xml output", function(){
@@ -241,7 +253,7 @@
             describe("suite result generation", function() {
                 var suites;
                 beforeEach(function() {
-                    setupReporterWithOptions({consolidateAll:true, consolidate:true});
+                    setupReporterWithOptions({consolidateAll:true, consolidate:true, package:'testpackage'});
                     triggerRunnerEvents();
                     suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
                 });
@@ -265,6 +277,9 @@
                 });
                 it("should include hostname, simply because the JUnit XSD says it is required", function() {
                     expect(suites[0].getAttribute('hostname')).toBe('localhost');
+                });
+                it("should contain package", function () {
+                    expect(suites[0].getAttribute('package')).toBe('testpackage');
                 });
             });
             describe("spec result generation", function() {

--- a/test/JUnitXmlReporterSpec.js
+++ b/test/JUnitXmlReporterSpec.js
@@ -111,7 +111,7 @@
                 });
             });
 
-            describe("package", function() {
+            describe("package", function () {
                 it("should default output package to be empty", function () {
                     expect(reporter.package).toBe("");
                 });
@@ -121,7 +121,7 @@
                     });
                     expect(reporter.package).toBe("testpackage");
                 });
-                })
+            });
         });
 
         describe("generated xml output", function(){


### PR DESCRIPTION
This PR creates a new optional parameter for the JUnit-Report called package which holds the base package of the test suites that are handled by this reporter. The parameter defaults to `''`.

The purpose of this change is to be able to specify a general classification for tests that are handled by this reporter. Otherwise all these tests have the root package in Jenkins test result aggregation. 