### PR TITLE
fix broken testrunner in phantom 2.0 by using system args vs phantom.args

### DIFF
--- a/bin/phantomjs-testrunner.js
+++ b/bin/phantomjs-testrunner.js
@@ -1,6 +1,15 @@
 /* globals jasmineRequire, phantom */
 // Verify arguments
-if (phantom.args.length === 0) {
+var system = require('system');
+var args;
+
+if(phantom.args) {
+    args = phantom.args;
+} else {
+    args = system.args.slice(1);//use system args for phantom 2.0+
+}
+
+if (args.length === 0) {
     console.log("Simple JasmineBDD test runner for phantom.js");
     console.log("Usage: phantomjs-testrunner.js url_to_runner.html");
     console.log("Accepts http:// and file:// urls");
@@ -9,7 +18,6 @@ if (phantom.args.length === 0) {
     phantom.exit(2);
 }
 else {
-    var args = phantom.args;
     var fs = require("fs"),
         pages = [],
         page, address, resultsKey, i, l;
@@ -68,7 +76,6 @@ function logAndWorkAroundDefaultLineBreaking(msg) {
     var interpretAsWithoutNewline = /(^(\033\[\d+m)*[\.F](\033\[\d+m)*$)|( \.\.\.$)/;
     if (navigator.userAgent.indexOf("Windows") < 0 && interpretAsWithoutNewline.test(msg)) {
         try {
-            var system = require('system');
             system.stdout.write(msg);
         } catch (e) {
             var fs = require('fs');


### PR DESCRIPTION
I noticed trying to run the jasmine reporter as suggested in readme file that the bin/phantomjs-testrunner.js does not work with Phantom 2.x because phantom.args no longer works and you must use system args instead.  

My pull request updates phantom.args to system.args.  I hope you'll pull this fix in so that others with phantom 2 installed can use your reporters and thanks for the great work on this stuff.  I've been using jasmine-reporters for years now.