### PR TITLE
+ added delegate for being able to modify the suite name, added usage…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,7 +116,8 @@ per capability.
     onPrepare: function() {
         var jasmineReporters = require('jasmine-reporters');
         
-        browser.getProcessedConfig().then(function (config) {
+        // returning the promise makes protractor wait for the reporter config before executing tests
+        return browser.getProcessedConfig().then(function (config) {
             
             var cap = config.capabilities;
             var browserPlatform = cap.platform || cap.platformName || "ANY_PLATFORM";


### PR DESCRIPTION
… example in readme, added unit test

This pull request enables to use jasmine-reporters for solving issue https://github.com/angular/protractor/issues/1195 by making use of https://github.com/angular/protractor/pull/1724

I deployed the quick fix provided here https://github.com/irrenhaus/jasmine-reporters/commit/dc6b837f7014659253b5adfe5f2b3e43b4645ff8 in another branch https://github.com/reppners/jasmine-reporters/tree/quick-fix 

Without this fix the new protractor api is not usable yet but I wanted to keep this feature separate from a possible fix for this issue.

I could not run the tests because of some issue in PhantomJS though.