### PR TITLE
Newline whitespace per spec fix for terminal reporter

### DIFF
--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -22,7 +22,7 @@
     }
     function log(str) {
         var con = global.console || console;
-        if (con && con.log) {
+        if (con && con.log && str && str.length) {
             con.log(str);
         }
     }


### PR DESCRIPTION
Make sure there is content in the string before writing to console.  Fixes issue where there is an empty line per spec in the output with verbosity of 1 set.