### PR TITLE
Avoid empty messages on the console

### DIFF
--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -157,7 +157,9 @@
             } else if (self.verbosity > 2) {
                 resultText = ' ' + (failed ? 'Failed' : skipped ? 'Skipped' : disabled ? 'Disabled' : 'Passed');
             }
-            log(inColor(resultText, color));
+            if (resultText) {
+                log(inColor(resultText, color));
+            }
 
             if (failed) {
                 if (self.verbosity === 1) {


### PR DESCRIPTION
This is something we've experienced recently. If `verbosity` level of the `TerminalReporter` is 1 and there are focused and disabled tests, we are getting an empty console line for every disabled tests we've got (we had about 200 disabled tests, which resulted into 200 empty lines on the console).