### PR TITLE
Adds system-out callback option

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -121,6 +121,7 @@
 
         var delegates = {};
         delegates.modifySuiteName = options.modifySuiteName;
+        delegates.systemOut = options.systemOut;
 
         var suites = [],
             currentSuite = null,
@@ -344,8 +345,12 @@
                 }
             }
 
-            if (testCaseBody) {
-                xml += '>' + testCaseBody + '\n  </testcase>';
+            if (testCaseBody || delegates.systemOut) {
+                xml += '>' + testCaseBody;
+                if (delegates.systemOut) {
+                    xml += '\n   <system-out>' + trim(escapeInvalidXmlChars(delegates.systemOut(spec, getFullyQualifiedSuiteName(spec._suite, true)))) + '</system-out>';
+                }
+                xml += '\n  </testcase>';
             } else {
                 xml += ' />';
             }


### PR DESCRIPTION
This change allows the addition of a `<system-out></system-out>` block to each `<testcase>`. This is useful for adding extra information that can be used in CI systems like Jenkins / Hudson.

For example, using something like protractor-screenshot-reporter, this allows us to add `[[ATTACHMENT|spec/as/filename/description.png]]` for use in the JUnit Attachments Plugin.