### PR TITLE
Add duration calculation to AppveyorReporter

### DIFF
--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -39,7 +39,7 @@
      * @param {object} [options]
      * @param {number} [options.verbosity] meaningful values are 0 through 3; anything
      *   greater than 3 is treated as 3 (default: 2)
-     * @param {boolean} [options.color] print in color or not (default: true)
+     * @param {boolean} [options.color] print in color or not (default: false)
      * @param {boolean} [options.showStack] show stack trace for failed specs (default: false)
      */
     var DEFAULT_VERBOSITY = 2,


### PR DESCRIPTION
Add duration calculation same as in the JUnit reporter.

Fixed a small bug in the TerminalReporter option comments. The default value of option parameter color is `false`.