### PR TITLE
TAP reporter to display the expectationResult message

### DIFF
--- a/src/jasmine.tap_reporter.js
+++ b/src/jasmine.tap_reporter.js
@@ -39,7 +39,7 @@
 
         reportSpecResults: function(spec) {
             var resultText = "not ok";
-            var errorMessage = '';
+            var errorMessage = [];
 
             var results = spec.results();
             if (results.skipped) {
@@ -56,16 +56,34 @@
             } else {
                 var items = results.getItems();
                 var i = 0;
-                var expectationResult, stackMessage;
+                var expectationResult;
                 while (expectationResult = items[i++]) {
                     if (expectationResult.trace) {
-                        stackMessage = expectationResult.trace.stack? expectationResult.trace.stack : expectationResult.message;
-                        errorMessage += '\n  '+ stackMessage;
+                        var at_line;
+                        if (expectationResult.trace.stack) {
+                            var stack = expectationResult.trace.stack.split('\n');
+                            var j = 0;
+                            var s;
+                            while (s = stack[j++]) {
+                                if (!at_line && ! s.match(/jasmine/gi) ) {
+                                    var m = s.match(/https?:\/\/[^\/]+\/(.*):([0-9]+):[0-9]+$/);
+                                    at_line = ' ( At line ' + m[2] + ' in file ' + m[1] + ' )';
+                                }
+                            }
+                        }
+                        if (at_line) {
+                            errorMessage.push('#  ' + expectationResult.message + at_line);
+                        }
+                        else {
+                            errorMessage.push('#  ' + expectationResult.message);
+                            errorMessage.push('#  Stacktrace: ' + expectationResult.trace.stack);
+                        }
                     }
                 }
             }
 
-            this.log(resultText +" "+ (spec.id + 1) +" - "+ spec.suite.description +" : "+ spec.description + errorMessage);
+            var errorMessageText = errorMessage.length > 0 ? ("\n" + errorMessage.join("\n")) : '';
+            this.log(resultText +" "+ (spec.id + 1) +" - "+ spec.suite.description +" : "+ spec.description + errorMessageText);
         },
 
         reportRunnerResults: function(runner) {

--- a/src/jasmine.tap_reporter.js
+++ b/src/jasmine.tap_reporter.js
@@ -65,7 +65,7 @@
                             var j = 0;
                             var s;
                             while (s = stack[j++]) {
-                                if (!at_line && ! s.match(/jasmine/gi) ) {
+                                if (! s.match(/jasmine/gi) ) {
                                     var m = s.match(/https?:\/\/[^\/]+\/(.*):([0-9]+):[0-9]+$/);
                                     at_line = ' ( At line ' + m[2] + ' in file ' + m[1] + ' )';
                                 }
@@ -76,7 +76,9 @@
                         }
                         else {
                             errorMessage.push('#  ' + expectationResult.message);
-                            errorMessage.push('#  Stacktrace: ' + expectationResult.trace.stack);
+                            if (expectationResult.trace.stack) {
+                                errorMessage.push('#  Stacktrace: ' + expectationResult.trace.stack);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This change modifies the TAP reporter to display the expectationResult message.
It will also attempt to display the originating line and file if it is an error
and only display a stack trace if no line number found and a stack is available.