### PR TITLE
modifySuiteName must modify the filename too

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -287,6 +287,10 @@
                 fullName = suite.fullName;
             }
 
+            if(delegates.modifySuiteName) {
+                fullName = options.modifySuiteName(fullName, suite);
+            }
+
             // Either remove or escape invalid XML characters
             if (isFilename) {
                 var fileName = "",
@@ -301,10 +305,6 @@
                 }
                 return fileName;
             } else {
-
-                if(delegates.modifySuiteName) {
-                    fullName = options.modifySuiteName(fullName, suite);
-                }
 
                 return escapeInvalidXmlChars(fullName);
             }


### PR DESCRIPTION
Maybe related to #121 

According to in-src-doc about `modifySuiteName`:

> A delegate for letting the consumer modify the suite name when it is used inside the junit report and as a file name.

But it is not calling the method `modifySuiteName` to generate the file. This fix tries to call this method always.

Thank you.