### PR TITLE
Replace octal literals so that we can support strict mode.

### DIFF
--- a/bin/phantomjs-testrunner.js
+++ b/bin/phantomjs-testrunner.js
@@ -72,7 +72,7 @@ else {
  * @param msg
  */
 function logAndWorkAroundDefaultLineBreaking(msg) {
-    var interpretAsWithoutNewline = /(^(\033\[\d+m)*[\.F](\033\[\d+m)*$)|( \.\.\.$)/;
+    var interpretAsWithoutNewline = /(^(\u001b\[\d+m)*[\.F](\u001b\[\d+m)*$)|( \.\.\.$)/;
     if (navigator.userAgent.indexOf("Windows") < 0 && interpretAsWithoutNewline.test(msg)) {
         try {
             system.stdout.write(msg);

--- a/src/appveyor_reporter.js
+++ b/src/appveyor_reporter.js
@@ -119,9 +119,9 @@
             }
 
             for(i = 0; i < color_attributes.length; i++) {
-                ansi_string += "\033[" + ATTRIBUTES_TO_ANSI[color_attributes[i]] + "m";
+                ansi_string += "\u001b[" + ATTRIBUTES_TO_ANSI[color_attributes[i]] + "m";
             }
-            ansi_string += string + "\033[" + ATTRIBUTES_TO_ANSI["off"] + "m";
+            ansi_string += string + "\u001b[" + ATTRIBUTES_TO_ANSI["off"] + "m";
 
             return ansi_string;
         }

--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -256,9 +256,9 @@
             }
 
             for(i = 0; i < color_attributes.length; i++) {
-                ansi_string += "\033[" + ATTRIBUTES_TO_ANSI[color_attributes[i]] + "m";
+                ansi_string += "\u001b[" + ATTRIBUTES_TO_ANSI[color_attributes[i]] + "m";
             }
-            ansi_string += string + "\033[" + ATTRIBUTES_TO_ANSI["off"] + "m";
+            ansi_string += string + "\u001b[" + ATTRIBUTES_TO_ANSI["off"] + "m";
 
             return ansi_string;
         }


### PR DESCRIPTION
This repo seems to be the best bet so far for creating reports for Jest, but Jest requires strict mode, which disallows octal literals. These changes fix that issue.