### PR TITLE
fix bug spec._suite._failures not defined

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -268,6 +268,7 @@
         self.specDone = function(spec) {
             spec = getSpec(spec);
             spec._endTime = new Date();
+            spec._suite = currentSuite;
             storeOutput(spec);
             if (isSkipped(spec)) { spec._suite._skipped++; }
             if (isDisabled(spec)) { spec._suite._disabled++; }


### PR DESCRIPTION
Currently there is a bug when running the Junit reporter with Phantomjs and Gulp.

```
/vagrant/node_modules/jasmine-reporters/src/junit_reporter.js:274
            if (isFailed(spec)) { spec._suite._failures += spec.failedExpectations.length; }
                                             ^

TypeError: Cannot read property '_failures' of undefined
```

The cause is that _suite would be missing on getSpec(spec).
A simple redefine spec._suite to currentSuite would fix this error. 
and generate the Xml like intended.

