### PR TITLE
If the failure message or stack contains colors, the XML will render invalid

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -31,13 +31,17 @@
             pad(d.getMinutes()) + ':' +
             pad(d.getSeconds());
     }
+    function escapeControlChars(str) {
+        // Remove control character from Jasmine default output
+        return str.replace(/[\x1b]/g, "");
+    }
     function escapeInvalidXmlChars(str) {
-        return str.replace(/\&/g, "&amp;")
+        const escaped = str.replace(/\&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;")
-            .replace(/[\x1b]/g, ""); //Remove control character from Jasmine default output
+            .replace(/\'/g, "&apos;");
+        return escapeControlChars(escaped);
     }
     function getQualifiedFilename(path, filename, separator) {
         if (path && path.substr(-1) !== separator && filename.substr(0) !== separator) {
@@ -443,7 +447,7 @@
                     testCaseBody += '\n   <failure type="' + (failure.matcherName || "exception") + '"';
                     testCaseBody += ' message="' + trim(escapeInvalidXmlChars(failure.message))+ '"';
                     testCaseBody += '>';
-                    testCaseBody += '<![CDATA[' + trim(escapeInvalidXmlChars(failure.stack || failure.message)) + ']]>';
+                    testCaseBody += '<![CDATA[' + trim(escapeControlChars(failure.stack || failure.message)) + ']]>';
                     testCaseBody += '\n   </failure>';
                 }
             }

--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -443,7 +443,7 @@
                     testCaseBody += '\n   <failure type="' + (failure.matcherName || "exception") + '"';
                     testCaseBody += ' message="' + trim(escapeInvalidXmlChars(failure.message))+ '"';
                     testCaseBody += '>';
-                    testCaseBody += '<![CDATA[' + trim(failure.stack || failure.message) + ']]>';
+                    testCaseBody += '<![CDATA[' + trim(escapeInvalidXmlChars(failure.stack || failure.message)) + ']]>';
                     testCaseBody += '\n   </failure>';
                 }
             }

--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -36,7 +36,7 @@
         return str.replace(/[\x1b]/g, "");
     }
     function escapeInvalidXmlChars(str) {
-        const escaped = str.replace(/\&/g, "&amp;")
+        var escaped = str.replace(/\&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/\>/g, "&gt;")
             .replace(/\"/g, "&quot;")


### PR DESCRIPTION
The attached file was produced with the JUnitXmlReporter: [test-results.xml.zip](https://github.com/larrymyers/jasmine-reporters/files/1158960/test-results.xml.zip)

It is invalid XML as a `<![CDATA[` blob contains the 0x1B byte on line 1045 at column 71, which is not proper UTF-8.

This PR introduces `escapeControlChars` which is a less agressive escape function that is now used by `escapeInvalidXmlChars` after escaping <, />, etc.

`escapeControlChars` now wraps the failure.stack || failure.message to get rid of the unwanted bytes.
