### PR TITLE
Enable a minimal ESLint configuration and fix violations

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,22 @@
+env:
+  browser: true
+  commonjs: true
+  es6: true
+  node: true
+extends: eslint:recommended
+rules:
+  indent:
+    - error
+    - 4
+  linebreak-style:
+    - error
+    - unix
+  no-console: off
+  no-control-regex: off
+  quotes:
+    - error
+    - double
+    - avoidEscape: true
+  semi:
+    - error
+    - always

--- a/bin/phantomjs-testrunner.js
+++ b/bin/phantomjs-testrunner.js
@@ -1,6 +1,6 @@
-/* globals jasmineRequire, phantom */
+/* globals phantom */
 // Verify arguments
-var system = require('system');
+var system = require("system");
 var args;
 
 if(phantom.args) {
@@ -72,13 +72,13 @@ else {
  * @param msg
  */
 function logAndWorkAroundDefaultLineBreaking(msg) {
-    var interpretAsWithoutNewline = /(^(\u001b\[\d+m)*[\.F](\u001b\[\d+m)*$)|( \.\.\.$)/;
+    var interpretAsWithoutNewline = /(^(\u001b\[\d+m)*[.F](\u001b\[\d+m)*$)|( \.\.\.$)/;
     if (navigator.userAgent.indexOf("Windows") < 0 && interpretAsWithoutNewline.test(msg)) {
         try {
             system.stdout.write(msg);
         } catch (e) {
-            var fs = require('fs');
-            fs.write('/dev/stdout', msg, 'w');
+            var fs = require("fs");
+            fs.write("/dev/stdout", msg, "w");
         }
     } else {
         console.log(msg);
@@ -219,7 +219,7 @@ function processPage(status, page, resultsKey) {
             else {
                 timeout -= loopInterval;
                 if (timeout <= 0) {
-                    console.log('Page has timed out; aborting.');
+                    console.log("Page has timed out; aborting.");
                     page.__exit_code = 2;
                     clearInterval(ival);
                 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "homepage": "https://github.com/larrymyers/jasmine-reporters",
   "maintainers": "Ben Loveridge <bloveridge@gmail.com>",
   "scripts": {
-    "test": "jasmine"
+    "lint": "eslint . --report-unused-disable-directives",
+    "test-only": "jasmine",
+    "test": "npm run test-only && npm run lint"
   },
   "repository": {
     "type": "git",
@@ -17,6 +19,7 @@
     "xmldom": "^0.1.22"
   },
   "devDependencies": {
+    "eslint": "^4.11.0",
     "jasmine": "^2.4.1"
   },
   "licenses": [

--- a/spec/JUnitXmlReporterSpec.js
+++ b/spec/JUnitXmlReporterSpec.js
@@ -1,8 +1,8 @@
 /* globals jasmine, describe, afterEach, beforeEach, it, expect */
-var jasmineReporters = require('../index');
-var DOMParser = require('xmldom').DOMParser;
+var jasmineReporters = require("../index");
+var DOMParser = require("xmldom").DOMParser;
 
-var env, spec, suite,
+var env, suite,
     reporter, writeCalls, suiteId=0, specId=0, noop=function(){};
 function fakeSpec(ste, name) {
     var s = new jasmine.Spec({
@@ -42,8 +42,8 @@ function triggerRunnerEvents(callback) {
     reporter.jasmineStarted();
     for (var i=0; i<env._suites.length; i++) {
         var s = env._suites[i];
-        if(callback && typeof(callback) === 'function') {
-           callback();
+        if(callback && typeof(callback) === "function") {
+            callback();
         }
         triggerSuiteEvents(s);
     }
@@ -79,7 +79,7 @@ describe("JUnitXmlReporter", function(){
     beforeEach(function(){
         env = new jasmine.Env();
         suite = fakeSuite("ParentSuite");
-        spec = fakeSpec(suite, "should be a dummy with invalid characters: & < > \" '");
+        fakeSpec(suite, "should be a dummy with invalid characters: & < > \" '");
         setupReporterWithOptions();
     });
 
@@ -98,10 +98,10 @@ describe("JUnitXmlReporter", function(){
         });
 
         describe("file prefix", function(){
-            it("should default output file prefix to \'junitresults\'", function () {
+            it("should default output file prefix to 'junitresults'", function () {
                 expect(reporter.filePrefix).toBe("junitresults");
             });
-            it("should default output file prefix to \'junitresults-\' if consolidateAll is false", function () {
+            it("should default output file prefix to 'junitresults-' if consolidateAll is false", function () {
                 setupReporterWithOptions({
                     consolidateAll: false
                 });
@@ -110,7 +110,7 @@ describe("JUnitXmlReporter", function(){
             it("should prefix suite names if consolidateAll is false", function () {
                 setupReporterWithOptions({
                     consolidateAll: false,
-                    filePrefix: 'alt-prefix-'
+                    filePrefix: "alt-prefix-"
                 });
                 triggerRunnerEvents();
                 expect(reporter.writeFile).toHaveBeenCalledWith("alt-prefix-ParentSuite.xml", jasmine.any(String));
@@ -125,7 +125,7 @@ describe("JUnitXmlReporter", function(){
                 setupReporterWithOptions({package:true});
                 expect(reporter.package).toBeUndefined();
 
-                setupReporterWithOptions({package:['test']});
+                setupReporterWithOptions({package:["test"]});
                 expect(reporter.package).toBeUndefined();
             });
             it("should set output package to the provided string", function () {
@@ -142,7 +142,7 @@ describe("JUnitXmlReporter", function(){
                 setupReporterWithOptions({stylesheetPath:true});
                 expect(reporter.stylesheetPath).toBeUndefined();
 
-                setupReporterWithOptions({stylesheetPath:''});
+                setupReporterWithOptions({stylesheetPath:""});
                 expect(reporter.stylesheetPath).toBeUndefined();
             });
             it("should set output stylesheetPath to the provided string", function () {
@@ -160,18 +160,18 @@ describe("JUnitXmlReporter", function(){
     });
 
     function assertTestsuitesTagAttributes(testSuitesTag, {disabled, errors, failures, tests} = {}) {
-        expect(testSuitesTag.getAttribute('disabled')).toBe(disabled);
-        expect(testSuitesTag.getAttribute('errors')).toBe(errors);
-        expect(testSuitesTag.getAttribute('failures')).toBe(failures);
-        expect(testSuitesTag.getAttribute('tests')).toBe(tests);
-    };
+        expect(testSuitesTag.getAttribute("disabled")).toBe(disabled);
+        expect(testSuitesTag.getAttribute("errors")).toBe(errors);
+        expect(testSuitesTag.getAttribute("failures")).toBe(failures);
+        expect(testSuitesTag.getAttribute("tests")).toBe(tests);
+    }
 
 
     it("the testsuites tags should include a time attribute", function() {
-        var testSuitesTags = writeCalls[0].xmldoc.getElementsByTagName('testsuites');
+        var testSuitesTags = writeCalls[0].xmldoc.getElementsByTagName("testsuites");
         expect(testSuitesTags.length).toBe(1);
         var testSuitesTag =  testSuitesTags[0];
-        expect(testSuitesTag.getAttribute('time')).not.toBe('');
+        expect(testSuitesTag.getAttribute("time")).not.toBe("");
     });
 
     describe("no xml output generation", function() {
@@ -182,8 +182,8 @@ describe("JUnitXmlReporter", function(){
 
         it("testsuites tags should default disabled, errors, failures to 0 when undefined", function() {
             assertTestsuitesTagAttributes(
-                writeCalls[0].xmldoc.getElementsByTagName('testsuites')[0],
-                {disabled: '0', errors: '0', failures: '0', tests: '1'});
+                writeCalls[0].xmldoc.getElementsByTagName("testsuites")[0],
+                {disabled: "0", errors: "0", failures: "0", tests: "1"});
         });
     });
 
@@ -200,7 +200,7 @@ describe("JUnitXmlReporter", function(){
         function itShouldHaveOneTestsuitesElementPerFile() {
             it("should include xml preamble once in all files", function() {
                 for (var i=0; i<writeCalls.length; i++) {
-                    expect(writeCalls[i].xmldoc.getElementsByTagName('testsuites').length).toBe(1);
+                    expect(writeCalls[i].xmldoc.getElementsByTagName("testsuites").length).toBe(1);
                 }
             });
         }
@@ -223,54 +223,54 @@ describe("JUnitXmlReporter", function(){
                 message: "Expected true to be false.",
                 expected: false,
                 actual: true,
-                matcherName: 'toBe',
+                matcherName: "toBe",
                 stack: "Stack trace! Stack trackes are cool & can have \"special\" characters <3\n\n Neat: yes."
             });
         });
 
         describe("consolidateAll=true", function() {
             beforeEach(function() {
-                setupReporterWithOptions({consolidateAll:true, filePrefix:'results'});
+                setupReporterWithOptions({consolidateAll:true, filePrefix:"results"});
                 triggerRunnerEvents();
             });
             it("should only write a single file", function() {
                 expect(writeCalls.length).toBe(1);
             });
             it("should include results for all test suites", function() {
-                expect(writeCalls[0].xmldoc.getElementsByTagName('testsuite').length).toBe(4);
+                expect(writeCalls[0].xmldoc.getElementsByTagName("testsuite").length).toBe(4);
             });
             it("should write a single file using filePrefix as the filename", function() {
-                expect(writeCalls[0].args[0]).toBe('results.xml');
+                expect(writeCalls[0].args[0]).toBe("results.xml");
             });
             it("testsuites tags should include disabled, errors, failures, and tests (count) when defined", function() {
                 assertTestsuitesTagAttributes(
-                    writeCalls[0].xmldoc.getElementsByTagName('testsuites')[0],
-                    {disabled: '1', errors: '0', failures: '1', tests: '7'});
+                    writeCalls[0].xmldoc.getElementsByTagName("testsuites")[0],
+                    {disabled: "1", errors: "0", failures: "1", tests: "7"});
             });
             itShouldHaveOneTestsuitesElementPerFile();
             itShouldIncludeXmlPreambleInAllFiles();
         });
         describe("consolidatedAll=false, consolidate=true", function(){
             beforeEach(function(){
-                setupReporterWithOptions({consolidateAll:false, consolidate:true, filePrefix:'results-'});
+                setupReporterWithOptions({consolidateAll:false, consolidate:true, filePrefix:"results-"});
                 triggerRunnerEvents();
             });
             it("should write one file per parent suite", function(){
                 expect(writeCalls.length).toEqual(2);
             });
             it("should include results for top-level suite and its descendents", function() {
-                expect(writeCalls[0].xmldoc.getElementsByTagName('testsuite').length).toBe(3);
-                expect(writeCalls[1].xmldoc.getElementsByTagName('testsuite').length).toBe(1);
+                expect(writeCalls[0].xmldoc.getElementsByTagName("testsuite").length).toBe(3);
+                expect(writeCalls[1].xmldoc.getElementsByTagName("testsuite").length).toBe(1);
             });
             it("should construct filenames using filePrefix and suite description, removing bad characters", function() {
-                expect(writeCalls[0].args[0]).toBe('results-ParentSuite.xml');
-                expect(writeCalls[1].args[0]).toBe('results-SiblingSuiteWithInvalidChars.xml');
+                expect(writeCalls[0].args[0]).toBe("results-ParentSuite.xml");
+                expect(writeCalls[1].args[0]).toBe("results-SiblingSuiteWithInvalidChars.xml");
             });
             it("testsuites tags should include disabled, errors, failures, and tests (count) when defined", function() {
-                assertTestsuitesTagAttributes(writeCalls[0].xmldoc.getElementsByTagName('testsuites')[0],
-                    {disabled: '1', errors: '0', failures: '1', tests: '6'});
-                assertTestsuitesTagAttributes(writeCalls[1].xmldoc.getElementsByTagName('testsuites')[0],
-                    {disabled: '0', errors: '0', failures: '0', tests: '1'});
+                assertTestsuitesTagAttributes(writeCalls[0].xmldoc.getElementsByTagName("testsuites")[0],
+                    {disabled: "1", errors: "0", failures: "1", tests: "6"});
+                assertTestsuitesTagAttributes(writeCalls[1].xmldoc.getElementsByTagName("testsuites")[0],
+                    {disabled: "0", errors: "0", failures: "0", tests: "1"});
             });
             itShouldHaveOneTestsuitesElementPerFile();
             itShouldIncludeXmlPreambleInAllFiles();
@@ -278,7 +278,7 @@ describe("JUnitXmlReporter", function(){
         describe("consolidated=false", function(){
             beforeEach(function(){
                 // consolidateAll becomes a noop, we include it specifically to passively test that
-                setupReporterWithOptions({consolidateAll:true, consolidate:false, filePrefix:'results-'});
+                setupReporterWithOptions({consolidateAll:true, consolidate:false, filePrefix:"results-"});
                 triggerRunnerEvents();
             });
             it("should write one file per suite", function(){
@@ -286,13 +286,13 @@ describe("JUnitXmlReporter", function(){
             });
             it("should include results for a single suite", function() {
                 for (var i=0; i<writeCalls.length; i++) {
-                    expect(writeCalls[i].xmldoc.getElementsByTagName('testsuite').length).toBe(1);
+                    expect(writeCalls[i].xmldoc.getElementsByTagName("testsuite").length).toBe(1);
                 }
             });
             it("should construct filenames using filePrefix and suite description, always using dot notation for filenames", function() {
-                expect(writeCalls[0].args[0]).toBe('results-ParentSuite.SubSuite.SubSubSuite.xml');
-                expect(writeCalls[1].args[0]).toBe('results-ParentSuite.SubSuite.xml');
-                expect(writeCalls[2].args[0]).toBe('results-ParentSuite.xml');
+                expect(writeCalls[0].args[0]).toBe("results-ParentSuite.SubSuite.SubSubSuite.xml");
+                expect(writeCalls[1].args[0]).toBe("results-ParentSuite.SubSuite.xml");
+                expect(writeCalls[2].args[0]).toBe("results-ParentSuite.xml");
             });
             itShouldHaveOneTestsuitesElementPerFile();
             itShouldIncludeXmlPreambleInAllFiles();
@@ -310,8 +310,8 @@ describe("JUnitXmlReporter", function(){
                     triggerRunnerEvents();
                 });
                 it("should use suite descriptions separated by periods", function() {
-                    expect(writeCalls[0].xmldoc.getElementsByTagName('testsuite')[2].getAttribute('name')).toBe('ParentSuite.SubSuite.SubSubSuite');
-                    expect(writeCalls[0].xmldoc.getElementsByTagName('testcase')[2].getAttribute('classname')).toBe('ParentSuite.SubSuite.SubSubSuite');
+                    expect(writeCalls[0].xmldoc.getElementsByTagName("testsuite")[2].getAttribute("name")).toBe("ParentSuite.SubSuite.SubSubSuite");
+                    expect(writeCalls[0].xmldoc.getElementsByTagName("testcase")[2].getAttribute("classname")).toBe("ParentSuite.SubSuite.SubSubSuite");
                 });
             });
             describe("useDotNotation=false", function() {
@@ -320,8 +320,8 @@ describe("JUnitXmlReporter", function(){
                     triggerRunnerEvents();
                 });
                 it("should use suite descriptions separated by spaces", function() {
-                    expect(writeCalls[0].xmldoc.getElementsByTagName('testsuite')[2].getAttribute('name')).toBe('ParentSuite SubSuite SubSubSuite');
-                    expect(writeCalls[0].xmldoc.getElementsByTagName('testcase')[2].getAttribute('classname')).toBe('ParentSuite SubSuite SubSubSuite');
+                    expect(writeCalls[0].xmldoc.getElementsByTagName("testsuite")[2].getAttribute("name")).toBe("ParentSuite SubSuite SubSubSuite");
+                    expect(writeCalls[0].xmldoc.getElementsByTagName("testcase")[2].getAttribute("classname")).toBe("ParentSuite SubSuite SubSubSuite");
                 });
             });
         });
@@ -331,89 +331,88 @@ describe("JUnitXmlReporter", function(){
             beforeEach(function() {
                 setupReporterWithOptions({consolidateAll:true, consolidate:true});
                 triggerRunnerEvents();
-                suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
+                suites = writeCalls[0].xmldoc.getElementsByTagName("testsuite");
             });
             it("should include test suites in order", function() {
-                expect(suites[0].getAttribute('name')).toBe('ParentSuite');
-                expect(suites[1].getAttribute('name')).toContain('SubSuite');
-                expect(suites[2].getAttribute('name')).toContain('SubSubSuite');
-                expect(suites[3].getAttribute('name')).toContain('SiblingSuite');
+                expect(suites[0].getAttribute("name")).toBe("ParentSuite");
+                expect(suites[1].getAttribute("name")).toContain("SubSuite");
+                expect(suites[2].getAttribute("name")).toContain("SubSubSuite");
+                expect(suites[3].getAttribute("name")).toContain("SiblingSuite");
             });
             it("should include total / failed / skipped counts for each suite (ignoring descendent results)", function() {
-                expect(suites[1].getAttribute('tests')).toBe('1');
-                expect(suites[2].getAttribute('tests')).toBe('4');
-                expect(suites[2].getAttribute('skipped')).toBe('1');
-                expect(suites[2].getAttribute('failures')).toBe('1');
+                expect(suites[1].getAttribute("tests")).toBe("1");
+                expect(suites[2].getAttribute("tests")).toBe("4");
+                expect(suites[2].getAttribute("skipped")).toBe("1");
+                expect(suites[2].getAttribute("failures")).toBe("1");
             });
             it("should calculate duration", function() {
-                expect(Number(suites[0].getAttribute('time'))).not.toEqual(NaN);
+                expect(Number(suites[0].getAttribute("time"))).not.toEqual(NaN);
             });
             it("should include timestamp as an ISO date string without timezone", function() {
-                expect(suites[0].getAttribute('timestamp')).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+                expect(suites[0].getAttribute("timestamp")).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
             });
             it("should include hostname, simply because the JUnit XSD says it is required", function() {
-                expect(suites[0].getAttribute('hostname')).toBe('localhost');
+                expect(suites[0].getAttribute("hostname")).toBe("localhost");
             });
             describe("package", function() {
                 it("should not include the package attribute if it is not provided", function() {
                     setupReporterWithOptions({});
                     triggerRunnerEvents();
-                    suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
-                    expect(suites[0].getAttribute('package')).toBe('');
+                    suites = writeCalls[0].xmldoc.getElementsByTagName("testsuite");
+                    expect(suites[0].getAttribute("package")).toBe("");
                 });
                 it("should include the package attribute if a string is provided", function() {
                     setupReporterWithOptions({package:"testPackage"});
                     triggerRunnerEvents();
-                    suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
-                    expect(suites[0].getAttribute('package')).toBe("testPackage");
+                    suites = writeCalls[0].xmldoc.getElementsByTagName("testsuite");
+                    expect(suites[0].getAttribute("package")).toBe("testPackage");
                 });
                 it("should escape the string provided", function() {
                     setupReporterWithOptions({package:"testPackage <3"});
                     triggerRunnerEvents();
-                    suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
-                    expect(suites[0].getAttribute('package')).toBe("testPackage <3");
+                    suites = writeCalls[0].xmldoc.getElementsByTagName("testsuite");
+                    expect(suites[0].getAttribute("package")).toBe("testPackage <3");
                     expect(writeCalls[0].output).toContain('package="testPackage &lt;3"');
                 });
             });
         });
 
         describe("spec result generation", function() {
-            var suites, specs;
+            var specs;
             beforeEach(function() {
                 setupReporterWithOptions({consolidateAll:true, consolidate:true});
                 triggerRunnerEvents();
-                suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
-                specs = writeCalls[0].xmldoc.getElementsByTagName('testcase');
+                specs = writeCalls[0].xmldoc.getElementsByTagName("testcase");
             });
             it("should include specs in order", function() {
-                expect(specs[0].getAttribute('name')).toContain('should be a dummy');
-                expect(specs[5].getAttribute('name')).toBe('should be failed two levels down');
+                expect(specs[0].getAttribute("name")).toContain("should be a dummy");
+                expect(specs[5].getAttribute("name")).toBe("should be failed two levels down");
             });
             it("should escape bad xml characters in spec description", function() {
                 expect(writeCalls[0].output).toContain("&amp; &lt; &gt; &quot; &apos;");
             });
             it("should calculate duration", function() {
-                expect(Number(specs[0].getAttribute('time'))).not.toEqual(NaN);
+                expect(Number(specs[0].getAttribute("time"))).not.toEqual(NaN);
             });
             it("should include failed matcher name as the failure type", function() {
-                var failure = specs[5].getElementsByTagName('failure')[0];
-                expect(failure.getAttribute('type')).toBe('toBe');
+                var failure = specs[5].getElementsByTagName("failure")[0];
+                expect(failure.getAttribute("type")).toBe("toBe");
             });
             it("should include failure messages", function() {
-                var failure = specs[5].getElementsByTagName('failure')[0];
-                expect(failure.getAttribute('message')).toBe('Expected true to be false.');
+                var failure = specs[5].getElementsByTagName("failure")[0];
+                expect(failure.getAttribute("message")).toBe("Expected true to be false.");
             });
             it("should include stack traces for failed specs (using CDATA to preserve special characters)", function() {
-                var failure = specs[5].getElementsByTagName('failure')[0];
+                var failure = specs[5].getElementsByTagName("failure")[0];
                 expect(failure.textContent).toContain('cool & can have "special" characters <3');
             });
             it("should include <skipped/> for skipped specs", function() {
-                expect(specs[3].getElementsByTagName('skipped').length).toBe(1);
+                expect(specs[3].getElementsByTagName("skipped").length).toBe(1);
             });
         });
 
         describe("modifySuiteName", function(){
-            var suites, modification = '-modified';
+            var suites, modification = "-modified";
             beforeEach(function(){
                 // consolidateAll becomes a noop, we include it specifically to passively test that
                 setupReporterWithOptions({
@@ -424,12 +423,12 @@ describe("JUnitXmlReporter", function(){
                     }
                 });
                 triggerRunnerEvents();
-                suites = writeCalls[0].xmldoc.getElementsByTagName('testsuite');
+                suites = writeCalls[0].xmldoc.getElementsByTagName("testsuite");
             });
             it("should construct suitenames that contain modification", function() {
                 for (var i = 0, suite; i < suites.length; i++) {
                     suite = suites[i];
-                    expect(suite.getAttribute('name')).toContain(modification);
+                    expect(suite.getAttribute("name")).toContain(modification);
                 }
             });
             itShouldHaveOneTestsuitesElementPerFile();
@@ -437,7 +436,7 @@ describe("JUnitXmlReporter", function(){
         });
 
         describe("modifyReportFileName", function(){
-            var modification = '-modified';
+            var modification = "-modified";
             beforeEach(function(){
                 // consolidateAll becomes a noop, we include it specifically to passively test that
                 setupReporterWithOptions({
@@ -466,7 +465,7 @@ describe("JUnitXmlReporter", function(){
                 triggerRunnerEvents(function() {
                     console.log(testOutput);
                 });
-                specOutputs = writeCalls[0].xmldoc.getElementsByTagName('system-out');
+                specOutputs = writeCalls[0].xmldoc.getElementsByTagName("system-out");
             });
             afterEach(function() {
                 process.stdout.write = _stdoutWrite;

--- a/spec/NUnitXmlReporterSpec.js
+++ b/spec/NUnitXmlReporterSpec.js
@@ -1,6 +1,6 @@
 /* globals jasmine, describe, beforeEach, it, expect */
-var jasmineReporters = require('../index');
-var DOMParser = require('xmldom').DOMParser;
+var jasmineReporters = require("../index");
+var DOMParser = require("xmldom").DOMParser;
 
 var env, suite, subSuite, subSubSuite, siblingSuite,
     reporter, writeCalls, suiteId=0, specId=0, noop=function(){};
@@ -88,7 +88,7 @@ describe("NUnitXmlReporter", function(){
             message: "Expected true to be false.",
             expected: false,
             actual: true,
-            matcherName: 'toBe',
+            matcherName: "toBe",
             stack: "Stack trace! Stack trackes are cool & can have \"special\" characters <3\n\n Neat: yes."
         });
         fakeSpec(subSuite, "should be one level down");
@@ -104,18 +104,18 @@ describe("NUnitXmlReporter", function(){
             setupReporterWithOptions();
         });
         it("should default path to an empty string", function(){
-            expect(reporter.savePath).toBe('');
+            expect(reporter.savePath).toBe("");
         });
         it("should allow a custom path to be provided", function() {
-            setupReporterWithOptions({savePath:'/tmp'});
-            expect(reporter.savePath).toBe('/tmp');
+            setupReporterWithOptions({savePath:"/tmp"});
+            expect(reporter.savePath).toBe("/tmp");
         });
         it("should default filename to 'nunitresults.xml'", function(){
             expect(reporter.filename).toBe("nunitresults.xml");
         });
         it("should allow a custom filename to be provided", function() {
-            setupReporterWithOptions({filename:'results.xml'});
-            expect(reporter.filename).toBe('results.xml');
+            setupReporterWithOptions({filename:"results.xml"});
+            expect(reporter.filename).toBe("results.xml");
         });
         it("should default reportName to 'Jasmine Results'", function(){
             expect(reporter.reportName).toBe("Jasmine Results");
@@ -194,7 +194,7 @@ describe("NUnitXmlReporter", function(){
                     expect(failedSpec.getAttribute("success")).toBe("false");
                 });
                 it("should include the error for failed specs", function() {
-                    expect(failedSpec.getElementsByTagName("message")[0].textContent).toBe('Expected true to be false.');
+                    expect(failedSpec.getElementsByTagName("message")[0].textContent).toBe("Expected true to be false.");
                 });
                 it("should include the stack trace for failed specs", function() {
                     expect(failedSpec.getElementsByTagName("stack-trace")[0].textContent).toContain('cool & can have "special" characters <3');

--- a/spec/TeamCityReporterSpec.js
+++ b/spec/TeamCityReporterSpec.js
@@ -1,7 +1,7 @@
 /* globals jasmine, describe, beforeEach, it, expect */
-var jasmineReporters = require('../index');
+var jasmineReporters = require("../index");
 
-var env, suite, subSuite, subSubSuite, siblingSuite,
+var env, suite, subSuite, subSubSuite,
     reporter, suiteId=0, specId=0, noop=function(){};
 function fakeSpec(ste, name) {
     var s = new jasmine.Spec({
@@ -72,7 +72,7 @@ describe("TeamCityReporter", function(){
         suite = fakeSuite("ParentSuite");
         subSuite = fakeSuite("SubSuite", suite);
         subSubSuite = fakeSuite("SubSubSuite", subSuite);
-        siblingSuite = fakeSuite("SiblingSuite");
+        fakeSuite("SiblingSuite");
         var failedSpec = fakeSpec(subSubSuite, "should be failed");
         failedSpec.result.status = "failed";
         failedSpec.result.failedExpectations.push({
@@ -80,7 +80,7 @@ describe("TeamCityReporter", function(){
             message: "Expected true to be false.",
             expected: false,
             actual: true,
-            matcherName: 'toBe',
+            matcherName: "toBe",
             stack: "Stack trace! Stack traces are cool & can have \"special\" characters <3\n\n Neat: yes."
         });
         fakeSpec(subSuite, "should be one level down");
@@ -92,25 +92,25 @@ describe("TeamCityReporter", function(){
             setupReporterWithOptions();
             this.logs = triggerRunnerEvents();
         });
-        it('should log testSuiteStarted and testSuiteFinished events', function() {
+        it("should log testSuiteStarted and testSuiteFinished events", function() {
             // we have 4 suites
-            var started = this.logs.filter(l=>l.indexOf('testSuiteStarted') > -1);
-            var finished = this.logs.filter(l=>l.indexOf('testSuiteStarted') > -1);
+            var started = this.logs.filter(l=>l.indexOf("testSuiteStarted") > -1);
+            var finished = this.logs.filter(l=>l.indexOf("testSuiteStarted") > -1);
             expect(started.length).toBe(4);
             expect(finished.length).toBe(4);
             expect(started[0].indexOf("name='ParentSuite'")).toBeGreaterThan(-1);
         });
-        it('should log testStarted and testFinished events', function() {
+        it("should log testStarted and testFinished events", function() {
             // we have 3 specs
-            var started = this.logs.filter(l=>l.indexOf('testStarted') > -1);
-            var finished = this.logs.filter(l=>l.indexOf('testStarted') > -1);
+            var started = this.logs.filter(l=>l.indexOf("testStarted") > -1);
+            var finished = this.logs.filter(l=>l.indexOf("testStarted") > -1);
             expect(started.length).toBe(3);
             expect(finished.length).toBe(3);
             expect(started[0].indexOf("name='should be failed'")).toBeGreaterThan(-1);
         });
-        it('should log testFailed event including reason and stack trace', function() {
+        it("should log testFailed event including reason and stack trace", function() {
             // we have 1 failure
-            var failed = this.logs.filter(l=>l.indexOf('testFailed') > -1);
+            var failed = this.logs.filter(l=>l.indexOf("testFailed") > -1);
             expect(failed.length).toBe(1);
             expect(failed[0].indexOf("name='should be failed'")).toBeGreaterThan(-1);
             expect(failed[0].indexOf("message='Expected true to be false.'")).toBeGreaterThan(-1);
@@ -118,21 +118,21 @@ describe("TeamCityReporter", function(){
         });
     });
 
-    describe('modifySuiteName', function() {
-        var modification = '-modified';
+    describe("modifySuiteName", function() {
+        var modification = "-modified";
         beforeEach(function() {
             setupReporterWithOptions({modifySuiteName: function(name) { return name + modification; }});
             this.logs = triggerRunnerEvents();
         });
-        it('should use the modification for suite names', function() {
+        it("should use the modification for suite names", function() {
             // we have 4 suites
-            var started = this.logs.filter(l=>l.indexOf('testSuiteStarted') > -1);
+            var started = this.logs.filter(l=>l.indexOf("testSuiteStarted") > -1);
             started.forEach(e=>expect(e.indexOf(modification)).toBeGreaterThan(-1));
             expect(started[0].indexOf("name='ParentSuite-modified'")).toBeGreaterThan(-1);
         });
-        it('should *not* use the modification for spec names', function() {
+        it("should *not* use the modification for spec names", function() {
             // we have 3 specs
-            var started = this.logs.filter(l=>l.indexOf('testStarted') > -1);
+            var started = this.logs.filter(l=>l.indexOf("testStarted") > -1);
             started.forEach(e=>expect(e.indexOf(modification)).toBe(-1));
         });
     });

--- a/src/appveyor_reporter.js
+++ b/src/appveyor_reporter.js
@@ -144,21 +144,21 @@
 
             var http = require("http");
             var req =  http.request(options, function(res) {
-                log.debug(inColor('  STATUS: ' + res.statusCode, "yellow"));
-                log.debug(inColor('  HEADERS: ' + JSON.stringify(res.headers), "yellow"));
-                res.setEncoding('utf8');
+                log.debug(inColor("  STATUS: " + res.statusCode, "yellow"));
+                log.debug(inColor("  HEADERS: " + JSON.stringify(res.headers), "yellow"));
+                res.setEncoding("utf8");
 
-                res.on('data', function (chunk) {
-                    log.debug(inColor('  BODY: ' + chunk, "yellow"));
+                res.on("data", function (chunk) {
+                    log.debug(inColor("  BODY: " + chunk, "yellow"));
                 });
 
-                res.on('end', function() {
-                    log.debug(inColor('    RESPONSE END', "yellow"));
+                res.on("end", function() {
+                    log.debug(inColor("    RESPONSE END", "yellow"));
                 });
             });
 
-            req.on('error', function(e) {
-                log.debug(inColor('API request error: ' + e.message, "red"));
+            req.on("error", function(e) {
+                log.debug(inColor("API request error: " + e.message, "red"));
             });
 
             req.write(postData);

--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -14,7 +14,7 @@
     function isFailed(obj) { return obj.status === "failed"; }
     function isSkipped(obj) { return obj.status === "pending"; }
     function isDisabled(obj) { return obj.status === "disabled"; }
-    function pad(n) { return n < 10 ? '0'+n : n; }
+    function pad(n) { return n < 10 ? "0"+n : n; }
     function extend(dupe, obj) { // performs a shallow copy of all props of `obj` onto `dupe`
         for (var prop in obj) {
             if (obj.hasOwnProperty(prop)) {
@@ -24,11 +24,11 @@
         return dupe;
     }
     function ISODateString(d) {
-        return d.getFullYear() + '-' +
-            pad(d.getMonth()+1) + '-' +
-            pad(d.getDate()) + 'T' +
-            pad(d.getHours()) + ':' +
-            pad(d.getMinutes()) + ':' +
+        return d.getFullYear() + "-" +
+            pad(d.getMonth()+1) + "-" +
+            pad(d.getDate()) + "T" +
+            pad(d.getHours()) + ":" +
+            pad(d.getMinutes()) + ":" +
             pad(d.getSeconds());
     }
     function escapeControlChars(str) {
@@ -36,11 +36,11 @@
         return str.replace(/[\x1b]/g, "");
     }
     function escapeInvalidXmlChars(str) {
-        var escaped = str.replace(/\&/g, "&amp;")
+        var escaped = str.replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
-            .replace(/\>/g, "&gt;")
-            .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;");
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&apos;");
         return escapeControlChars(escaped);
     }
     function getQualifiedFilename(path, filename, separator) {
@@ -77,7 +77,7 @@
             console.log = (function(write) {
                 return function(string) {
                     write.apply(string);
-                    callback(string, 'utf8');
+                    callback(string, "utf8");
                 };
             })(old_write);
         }
@@ -173,32 +173,32 @@
         self.finished = false;
         // sanitize arguments
         options = options || {};
-        self.savePath = options.savePath || '';
+        self.savePath = options.savePath || "";
         self.consolidate = options.consolidate === UNDEFINED ? true : options.consolidate;
         self.consolidateAll = self.consolidate !== false && (options.consolidateAll === UNDEFINED ? true : options.consolidateAll);
         self.useDotNotation = options.useDotNotation === UNDEFINED ? true : options.useDotNotation;
         self.useFullTestName = options.useFullTestName === UNDEFINED ? false : options.useFullTestName;
         if (self.consolidateAll) {
-            self.filePrefix = options.filePrefix || 'junitresults';
+            self.filePrefix = options.filePrefix || "junitresults";
         } else {
-            self.filePrefix = typeof options.filePrefix === 'string' ? options.filePrefix : 'junitresults-';
+            self.filePrefix = typeof options.filePrefix === "string" ? options.filePrefix : "junitresults-";
         }
-        self.package = typeof(options.package) === 'string' ? escapeInvalidXmlChars(options.package) : UNDEFINED;
-        self.stylesheetPath = typeof(options.stylesheetPath) === 'string' && options.stylesheetPath || UNDEFINED;
+        self.package = typeof(options.package) === "string" ? escapeInvalidXmlChars(options.package) : UNDEFINED;
+        self.stylesheetPath = typeof(options.stylesheetPath) === "string" && options.stylesheetPath || UNDEFINED;
 
-        if(options.modifySuiteName && typeof options.modifySuiteName !== 'function') {
+        if(options.modifySuiteName && typeof options.modifySuiteName !== "function") {
             throw new Error('option "modifySuiteName" must be a function');
         }
-        if(options.modifyReportFileName && typeof options.modifyReportFileName !== 'function') {
+        if(options.modifyReportFileName && typeof options.modifyReportFileName !== "function") {
             throw new Error('option "modifyReportFileName" must be a function');
         }
-        if(options.systemOut && typeof options.systemOut !== 'function') {
+        if(options.systemOut && typeof options.systemOut !== "function") {
             throw new Error('option "systemOut" must be a function');
         }
 
         self.captureStdout = options.captureStdout || false;
         if(self.captureStdout && !options.systemOut) {
-            options.systemOut = function (spec, specName) { // jshint ignore:line
+            options.systemOut = function (spec) {
                 return spec._stdout;
             };
         }
@@ -213,13 +213,11 @@
 
         var suites = [],
             currentSuite = null,
-            totalSpecsExecuted = 0,
-            totalSpecsDefined,
             // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
             fakeFocusedSuite = {
-                id: 'focused',
-                description: 'focused specs',
-                fullName: 'focused specs'
+                id: "focused",
+                description: "focused specs",
+                fullName: "focused specs"
             };
 
         var __suites = {}, __specs = {};
@@ -237,12 +235,11 @@
             return ret;
         }
 
-        self.jasmineStarted = function(summary) {
-            totalSpecsDefined = summary && summary.totalSpecsDefined || NaN;
+        self.jasmineStarted = function() {
             exportObject.startTime = new Date();
             self.started = true;
             if(self.captureStdout) {
-                self.removeStdoutWrapper = hook_stdout(function(string, encoding, fd) { // jshint ignore:line
+                self.removeStdoutWrapper = hook_stdout(function(string) {
                     self.logEntries.push(string);
                 });
             }
@@ -279,7 +276,6 @@
             if (isSkipped(spec)) { spec._suite._skipped++; }
             if (isDisabled(spec)) { spec._suite._disabled++; }
             if (isFailed(spec)) { spec._suite._failures += spec.failedExpectations.length; }
-            totalSpecsExecuted++;
         };
         self.suiteDone = function(suite) {
             suite = getSuite(suite);
@@ -295,7 +291,7 @@
                 // focused spec (fit) -- suiteDone was never called
                 self.suiteDone(fakeFocusedSuite);
             }
-            var output = '';
+            var output = "";
             var testSuitesResults = { disabled: 0, failures: 0, tests: 0, time: 0 };
             for (var i = 0; i < suites.length; i++) {
                 output += self.getOrWriteNestedOutput(suites[i]);
@@ -303,7 +299,7 @@
                 var suiteResults = self.getNestedSuiteData(suites[i]);
                 for (var key in suiteResults) {
                     testSuitesResults[key] += suiteResults[key];
-                };
+                }
             }
             // if we have anything to write here, write out the consolidated file
             if (output) {
@@ -334,7 +330,7 @@
                 var childSuiteResults = self.getNestedSuiteData(suite._suites[i]);
                 for (var key in suiteResults) {
                     suiteResults[key] += childSuiteResults[key];
-                };
+                }
             }
             return suiteResults;
         };
@@ -349,7 +345,7 @@
             } else {
                 // if we aren't supposed to consolidate output, just write it now
                 wrapOutputAndWriteFile(generateFilename(suite), output, self.getNestedSuiteData(suite));
-                return '';
+                return "";
             }
         };
 
@@ -379,11 +375,11 @@
             try {
                 phantomWrite(path, filename, text);
                 return;
-            } catch (e) { errors.push('  PhantomJs attempt: ' + e.message); }
+            } catch (e) { errors.push("  PhantomJs attempt: " + e.message); }
             try {
                 nodeWrite(path, filename, text);
                 return;
-            } catch (f) { errors.push('  NodeJS attempt: ' + f.message); }
+            } catch (f) { errors.push("  NodeJS attempt: " + f.message); }
 
             // If made it here, no write succeeded.  Let user know.
             log("Warning: writing junit report failed for '" + path + "', '" +
@@ -394,15 +390,15 @@
 
         /******** Helper functions with closure access for simplicity ********/
         function generateFilename(suite) {
-            return self.filePrefix + getFullyQualifiedSuiteName(suite, true) + '.xml';
+            return self.filePrefix + getFullyQualifiedSuiteName(suite, true) + ".xml";
         }
-        
+
         function getFullyQualifiedSuiteName(suite, isFilename) {
             var fullName;
             if (self.useDotNotation || isFilename) {
                 fullName = suite.description;
                 for (var parent = suite._parent; parent; parent = parent._parent) {
-                    fullName = parent.description + '.' + fullName;
+                    fullName = parent.description + "." + fullName;
                 }
             } else {
                 fullName = suite.fullName;
@@ -411,7 +407,7 @@
             // Either remove or escape invalid XML characters
             if (isFilename) {
                 var fileName = "",
-                    rFileChars = /[\w\.]/,
+                    rFileChars = /[\w.]/,
                     chr;
                 while (fullName.length) {
                     chr = fullName[0];
@@ -448,47 +444,47 @@
             if (self.package) {
                 xml += ' package="' + self.package + '"';
             }
-            xml += '>';
+            xml += ">";
 
             for (var i = 0; i < suite._specs.length; i++) {
                 xml += specAsXml(suite._specs[i]);
             }
-            xml += '\n </testsuite>';
+            xml += "\n </testsuite>";
             return xml;
         }
         function specAsXml(spec) {
             var testName = self.useFullTestName ? spec.fullName : spec.description;
-            
+
             var xml = '\n  <testcase classname="' + getFullyQualifiedSuiteName(spec._suite) + '"';
             xml += ' name="' + escapeInvalidXmlChars(testName) + '"';
             xml += ' time="' + elapsed(spec._startTime, spec._endTime) + '"';
 
-            var testCaseBody = '';
+            var testCaseBody = "";
             if (isSkipped(spec) || isDisabled(spec)) {
                 if (spec.pendingReason) {
                     testCaseBody = '\n   <skipped message="' + trim(escapeInvalidXmlChars(spec.pendingReason)) + '" />';
                 } else {
-                    testCaseBody = '\n   <skipped />';
+                    testCaseBody = "\n   <skipped />";
                 }
             } else if (isFailed(spec)) {
                 for (var i = 0, failure; i < spec.failedExpectations.length; i++) {
                     failure = spec.failedExpectations[i];
                     testCaseBody += '\n   <failure type="' + (failure.matcherName || "exception") + '"';
                     testCaseBody += ' message="' + trim(escapeInvalidXmlChars(failure.message))+ '"';
-                    testCaseBody += '>';
-                    testCaseBody += '<![CDATA[' + trim(escapeControlChars(failure.stack || failure.message)) + ']]>';
-                    testCaseBody += '\n   </failure>';
+                    testCaseBody += ">";
+                    testCaseBody += "<![CDATA[" + trim(escapeControlChars(failure.stack || failure.message)) + "]]>";
+                    testCaseBody += "\n   </failure>";
                 }
             }
 
             if (testCaseBody || delegates.systemOut) {
-                xml += '>' + testCaseBody;
+                xml += ">" + testCaseBody;
                 if (delegates.systemOut) {
-                    xml += '\n   <system-out>' + trim(escapeInvalidXmlChars(delegates.systemOut(spec, getFullyQualifiedSuiteName(spec._suite, true)))) + '</system-out>';
+                    xml += "\n   <system-out>" + trim(escapeInvalidXmlChars(delegates.systemOut(spec, getFullyQualifiedSuiteName(spec._suite, true)))) + "</system-out>";
                 }
-                xml += '\n  </testcase>';
+                xml += "\n  </testcase>";
             } else {
-                xml += ' />';
+                xml += " />";
             }
             return xml;
         }
@@ -511,9 +507,9 @@
                 '" tests="' + results.tests + '" time="' + results.time + '">';
             return prefix;
         }
-        var suffix = '\n</testsuites>';
+        var suffix = "\n</testsuites>";
         function wrapOutputAndWriteFile(filename, text, testSuitesResults) {
-            if (filename.substr(-4) !== '.xml') { filename += '.xml'; }
+            if (filename.substr(-4) !== ".xml") { filename += ".xml"; }
             self.writeFile(filename, (getPrefix(testSuitesResults) + text + suffix));
         }
     };

--- a/src/nunit_reporter.js
+++ b/src/nunit_reporter.js
@@ -13,7 +13,7 @@
     function isFailed(obj) { return obj.status === "failed"; }
     function isSkipped(obj) { return obj.status === "pending"; }
     function isDisabled(obj) { return obj.status === "disabled"; }
-    function pad(n) { return n < 10 ? '0'+n : n; }
+    function pad(n) { return n < 10 ? "0"+n : n; }
     function extend(dupe, obj) { // performs a shallow copy of all props of `obj` onto `dupe`
         for (var prop in obj) {
             if (obj.hasOwnProperty(prop)) {
@@ -23,11 +23,11 @@
         return dupe;
     }
     function escapeInvalidXmlChars(str) {
-        return str.replace(/\&/g, "&amp;")
+        return str.replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
-            .replace(/\>/g, "&gt;")
-            .replace(/\"/g, "&quot;")
-            .replace(/\'/g, "&apos;");
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&apos;");
     }
     function dateString(date) {
         var year = date.getFullYear();
@@ -80,9 +80,9 @@
         self.finished = false;
         // sanitize arguments
         options = options || {};
-        self.savePath = options.savePath || '';
-        self.filename = options.filename || 'nunitresults.xml';
-        self.reportName = options.reportName || 'Jasmine Results';
+        self.savePath = options.savePath || "";
+        self.filename = options.filename || "nunitresults.xml";
+        self.reportName = options.reportName || "Jasmine Results";
 
         var suites = [],
             currentSuite = null,
@@ -93,9 +93,9 @@
             totalSpecsDefined,
             // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
             fakeFocusedSuite = {
-                id: 'focused',
-                description: 'focused specs',
-                fullName: 'focused specs'
+                id: "focused",
+                description: "focused specs",
+                fullName: "focused specs"
             };
 
         var __suites = {}, __specs = {};
@@ -214,11 +214,11 @@
             try {
                 phantomWrite(path, filename, text);
                 return;
-            } catch (e) { errors.push('  PhantomJs attempt: ' + e.message); }
+            } catch (e) { errors.push("  PhantomJs attempt: " + e.message); }
             try {
                 nodeWrite(path, filename, text);
                 return;
-            } catch (f) { errors.push('  NodeJS attempt: ' + f.message); }
+            } catch (f) { errors.push("  NodeJS attempt: " + f.message); }
 
             // If made it here, no write succeeded.  Let user know.
             log("Warning: writing nunit report failed for '" + path + "', '" +
@@ -241,25 +241,25 @@
             xml += ' not-run="' + skippedSpecs + '"';
             xml += ' date="' + dateString(date) + '"';
             xml += ' time="' + timeString(date) + '"';
-            xml += '>';
+            xml += ">";
 
             for (var i=0; i<suites.length; i++) {
-                xml += suiteAsXml(suites[i], ' ');
+                xml += suiteAsXml(suites[i], " ");
             }
-            xml += '\n</test-results>';
+            xml += "\n</test-results>";
             return xml;
         }
     };
 
     function suiteAsXml(suite, indent) {
-        indent = indent || '';
-        var i, xml = '\n' + indent + '<test-suite';
+        indent = indent || "";
+        var i, xml = "\n" + indent + "<test-suite";
         xml += ' name="' + escapeInvalidXmlChars(suite.description) + '"';
         xml += ' executed="' + !suite._disabled + '"';
         xml += ' success="' + !(suite._failures || suite._nestedFailures) + '"';
         xml += ' time="' + elapsed(suite._startTime, suite._endTime) + '"';
-        xml += '>';
-        xml += '\n' + indent + ' <results>';
+        xml += ">";
+        xml += "\n" + indent + " <results>";
 
         for (i=0; i<suite._suites.length; i++) {
             xml += suiteAsXml(suite._suites[i], indent+"  ");
@@ -267,26 +267,26 @@
         for (i=0; i<suite._specs.length; i++) {
             xml += specAsXml(suite._specs[i], indent+"  ");
         }
-        xml += '\n' + indent + ' </results>';
-        xml += '\n' + indent + '</test-suite>';
+        xml += "\n" + indent + " </results>";
+        xml += "\n" + indent + "</test-suite>";
         return xml;
     }
     function specAsXml(spec, indent) {
-        indent = indent || '';
-        var xml = '\n' + indent + '<test-case';
+        indent = indent || "";
+        var xml = "\n" + indent + "<test-case";
         xml += ' name="' + escapeInvalidXmlChars(spec.description) + '"';
         xml += ' executed="' + !(isSkipped(spec) || isDisabled(spec)) + '"';
         xml += ' success="' + !isFailed(spec) + '"';
         xml += ' time="' + elapsed(spec._startTime, spec._endTime) + '"';
-        xml += '>';
+        xml += ">";
         for (var i = 0, failure; i < spec.failedExpectations.length; i++) {
             failure = spec.failedExpectations[i];
-            xml += '\n' + indent + ' <failure>';
-            xml += '\n' + indent + '  <message><![CDATA[' + failure.message + ']]></message>';
-            xml += '\n' + indent + '  <stack-trace><![CDATA[' + failure.stack + ']]></stack-trace>';
-            xml += '\n' + indent + ' </failure>';
+            xml += "\n" + indent + " <failure>";
+            xml += "\n" + indent + "  <message><![CDATA[" + failure.message + "]]></message>";
+            xml += "\n" + indent + "  <stack-trace><![CDATA[" + failure.stack + "]]></stack-trace>";
+            xml += "\n" + indent + " </failure>";
         }
-        xml += '\n' + indent + '</test-case>';
+        xml += "\n" + indent + "</test-case>";
         return xml;
     }
 })(this);

--- a/src/tap_reporter.js
+++ b/src/tap_reporter.js
@@ -8,7 +8,6 @@
         exportObject = global.jasmineReporters = global.jasmineReporters || {};
     }
 
-    function trim(str) { return str.replace(/^\s+/, "" ).replace(/\s+$/, "" ); }
     function elapsed(start, end) { return (end - start)/1000; }
     function isFailed(obj) { return obj.status === "failed"; }
     function isSkipped(obj) { return obj.status === "pending"; }
@@ -52,9 +51,9 @@
             totalSpecsDefined,
             // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
             fakeFocusedSuite = {
-                id: 'focused',
-                description: 'focused specs',
-                fullName: 'focused specs'
+                id: "focused",
+                description: "focused specs",
+                fullName: "focused specs"
             };
 
         var __suites = {}, __specs = {};
@@ -80,38 +79,27 @@
             suite = getSuite(suite);
             currentSuite = suite;
         };
-        self.specStarted = function(spec) {
+        self.specStarted = function() {
             if (!currentSuite) {
                 // focused spec (fit) -- suiteStarted was never called
                 self.suiteStarted(fakeFocusedSuite);
             }
-            spec = getSpec(spec, currentSuite);
             totalSpecsExecuted++;
         };
         self.specDone = function(spec) {
             spec = getSpec(spec, currentSuite);
-            var resultStr = 'ok ' + totalSpecsExecuted + ' - ' + spec._suite.description + ' : ' + spec.description;
-            var failedStr = '';
+            var resultStr = "ok " + totalSpecsExecuted + " - " + spec._suite.description + " : " + spec.description;
             if (isFailed(spec)) {
                 totalSpecsFailed++;
-                resultStr = 'not ' + resultStr;
-                for (var i = 0, failure; i < spec.failedExpectations.length; i++) {
-                    failure = spec.failedExpectations[i];
-                    failedStr += '\n  ' + trim(failure.message);
-                    if (failure.stack && failure.stack !== failure.message) {
-                        failedStr += '\n  === STACK TRACE ===';
-                        failedStr += '\n  ' + failure.stack;
-                        failedStr += '\n  === END STACK TRACE ===';
-                    }
-                }
+                resultStr = "not " + resultStr;
             }
             if (isSkipped(spec)) {
                 totalSpecsSkipped++;
-                resultStr += ' # SKIP disabled by xit or similar';
+                resultStr += " # SKIP disabled by xit or similar";
             }
             if (isDisabled(spec)) {
                 totalSpecsDisabled++;
-                resultStr += ' # SKIP disabled by xit, ?spec=xyz or similar';
+                resultStr += " # SKIP disabled by xit, ?spec=xyz or similar";
             }
             log(resultStr);
         };
@@ -134,18 +122,18 @@
                 disabledSpecs = totalSpecs - totalSpecsExecuted + totalSpecsDisabled;
 
             if (totalSpecsExecuted === 0) {
-                log('1..0 # All tests disabled');
+                log("1..0 # All tests disabled");
             } else {
-                log('1..' + totalSpecsExecuted);
+                log("1.." + totalSpecsExecuted);
             }
-            var diagStr = '#';
-            diagStr = '# ' + totalSpecs + ' spec' + (totalSpecs === 1 ? '' : 's');
-            diagStr += ', ' + totalSpecsFailed + ' failure' + (totalSpecsFailed === 1 ? '' : 's');
-            diagStr += ', ' + totalSpecsSkipped + ' skipped';
-            diagStr += ', ' + disabledSpecs + ' disabled';
-            diagStr += ' in ' + dur + 's.';
+            var diagStr = "#";
+            diagStr = "# " + totalSpecs + " spec" + (totalSpecs === 1 ? "" : "s");
+            diagStr += ", " + totalSpecsFailed + " failure" + (totalSpecsFailed === 1 ? "" : "s");
+            diagStr += ", " + totalSpecsSkipped + " skipped";
+            diagStr += ", " + disabledSpecs + " disabled";
+            diagStr += " in " + dur + "s.";
             log(diagStr);
-            log('# NOTE: disabled specs are usually a result of xdescribe.');
+            log("# NOTE: disabled specs are usually a result of xdescribe.");
 
             self.finished = true;
             // this is so phantomjs-testrunner.js can tell if we're done executing

--- a/src/teamcity_reporter.js
+++ b/src/teamcity_reporter.js
@@ -11,8 +11,8 @@
     function isFailed(obj) { return obj.status === "failed"; }
     function isSkipped(obj) { return obj.status === "pending"; }
     function isDisabled(obj) { return obj.status === "disabled"; }
-    function pad(n) { return n < 10 ? '0'+n : n; }
-    function padThree(n) { return n < 10 ? '00'+n : n < 100 ? '0'+n : n; }
+    function pad(n) { return n < 10 ? "0"+n : n; }
+    function padThree(n) { return n < 10 ? "00"+n : n < 100 ? "0"+n : n; }
     function extend(dupe, obj) { // performs a shallow copy of all props of `obj` onto `dupe`
         for (var prop in obj) {
             if (obj.hasOwnProperty(prop)) {
@@ -22,12 +22,12 @@
         return dupe;
     }
     function ISODateString(d) {
-        return d.getUTCFullYear() + '-' +
-            pad(d.getUTCMonth()+1) + '-' +
-            pad(d.getUTCDate()) + 'T' +
-            pad(d.getUTCHours()) + ':' +
-            pad(d.getUTCMinutes()) + ':' +
-            pad(d.getUTCSeconds()) + '.' +
+        return d.getUTCFullYear() + "-" +
+            pad(d.getUTCMonth()+1) + "-" +
+            pad(d.getUTCDate()) + "T" +
+            pad(d.getUTCHours()) + ":" +
+            pad(d.getUTCMinutes()) + ":" +
+            pad(d.getUTCSeconds()) + "." +
             // TeamCity wants ss.SSS
             padThree(d.getUTCMilliseconds());
     }
@@ -52,7 +52,7 @@
         self.started = false;
         self.finished = false;
 
-        if(options.modifySuiteName && typeof options.modifySuiteName !== 'function') {
+        if(options.modifySuiteName && typeof options.modifySuiteName !== "function") {
             throw new Error('option "modifySuiteName" must be a function');
         }
 
@@ -60,12 +60,11 @@
         delegates.modifySuiteName = options.modifySuiteName;
 
         var currentSuite = null,
-            totalSpecsDefined,
             // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
             fakeFocusedSuite = {
-                id: 'focused',
-                description: 'focused specs',
-                fullName: 'focused specs'
+                id: "focused",
+                description: "focused specs",
+                fullName: "focused specs"
             };
 
         var __suites = {}, __specs = {};
@@ -78,8 +77,7 @@
             return __specs[spec.id];
         }
 
-        self.jasmineStarted = function(summary) {
-            totalSpecsDefined = summary && summary.totalSpecsDefined || NaN;
+        self.jasmineStarted = function() {
             exportObject.startTime = new Date();
             self.started = true;
             tclog("progressStart 'Running Jasmine Tests'");
@@ -100,7 +98,7 @@
             spec = getSpec(spec);
             tclog("testStarted", {
                 name: spec.description,
-                captureStandardOutput: 'true'
+                captureStandardOutput: "true"
             });
         };
         self.specDone = function(spec) {
@@ -157,7 +155,7 @@
                 }
                 for (var prop in attrs) {
                     if (attrs.hasOwnProperty(prop)) {
-                        if(delegates.modifySuiteName && message.indexOf('testSuite') === 0 && prop === 'name') {
+                        if(delegates.modifySuiteName && message.indexOf("testSuite") === 0 && prop === "name") {
                             attrs[prop] = delegates.modifySuiteName(attrs[prop]);
                         }
                         str += " " + prop + "='" + escapeTeamCityString(attrs[prop]) + "'";
@@ -173,12 +171,12 @@
         if(!str) {
             return "";
         }
-        if (Object.prototype.toString.call(str) === '[object Date]') {
+        if (Object.prototype.toString.call(str) === "[object Date]") {
             return ISODateString(str);
         }
 
         return str.replace(/\|/g, "||")
-            .replace(/\'/g, "|'")
+            .replace(/'/g, "|'")
             .replace(/\n/g, "|n")
             .replace(/\r/g, "|r")
             .replace(/\u0085/g, "|x")

--- a/src/terminal_reporter.js
+++ b/src/terminal_reporter.js
@@ -65,7 +65,7 @@
         self.color = options.color;
         self.showStack = options.showStack;
 
-        var indent_string = '  ',
+        var indent_string = "  ",
             startTime,
             currentSuite = null,
             totalSpecsExecuted = 0,
@@ -75,9 +75,9 @@
             totalSpecsDefined,
             // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
             fakeFocusedSuite = {
-                id: 'focused',
-                description: 'focused specs',
-                fullName: 'focused specs'
+                id: "focused",
+                description: "focused specs",
+                fullName: "focused specs"
             };
 
         var __suites = {}, __specs = {};
@@ -125,7 +125,7 @@
             }
             spec = getSpec(spec, currentSuite);
             if (self.verbosity > 2) {
-                log(indentWithLevel(spec._depth, spec.description + ' ...'));
+                log(indentWithLevel(spec._depth, spec.description + " ..."));
             }
         };
         self.specDone = function(spec) {
@@ -133,56 +133,56 @@
             var failed = false,
                 skipped = false,
                 disabled = false,
-                color = 'green',
-                resultText = '';
+                color = "green",
+                resultText = "";
             if (isSkipped(spec)) {
                 skipped = true;
-                color = 'cyan';
+                color = "cyan";
                 spec._suite._skipped++;
                 totalSpecsSkipped++;
             }
             if (isFailed(spec)) {
                 failed = true;
-                color = 'red';
+                color = "red";
                 spec._suite._failures++;
                 totalSpecsFailed++;
             }
             if (isDisabled(spec)) {
                 disabled = true;
-                color = 'yellow';
+                color = "yellow";
                 spec._suite._disabled++;
                 totalSpecsDisabled++;
             }
             totalSpecsExecuted++;
 
             if (self.verbosity === 2) {
-                resultText = failed ? 'F' : skipped ? 'S' : disabled ? 'D' : '.';
+                resultText = failed ? "F" : skipped ? "S" : disabled ? "D" : ".";
             } else if (self.verbosity > 2) {
-                resultText = ' ' + (failed ? 'Failed' : skipped ? 'Skipped' : disabled ? 'Disabled' : 'Passed');
+                resultText = " " + (failed ? "Failed" : skipped ? "Skipped" : disabled ? "Disabled" : "Passed");
             }
             log(inColor(resultText, color));
 
             if (skipped && spec.pendingReason) {
-              if (self.verbosity > 2) {
-                log(indentWithLevel(spec._depth, inColor(spec.pendingReason, color)));
-              }
-              else {
-                log(inColor(spec.pendingReason, color));
-              }
+                if (self.verbosity > 2) {
+                    log(indentWithLevel(spec._depth, inColor(spec.pendingReason, color)));
+                }
+                else {
+                    log(inColor(spec.pendingReason, color));
+                }
             }
 
             if (failed) {
                 if (self.verbosity === 1) {
                     log(spec.fullName);
                 } else if (self.verbosity === 2) {
-                    log(' ');
+                    log(" ");
                     log(indentWithLevel(spec._depth, spec.fullName));
                 }
 
                 for (var i = 0; i < spec.failedExpectations.length; i++) {
                     log(inColor(indentWithLevel(spec._depth, indent_string + spec.failedExpectations[i].message), color));
                     if (self.showStack){
-                        logStackLines(spec._depth, spec.failedExpectations[i].stack.split('\n'));
+                        logStackLines(spec._depth, spec.failedExpectations[i].stack.split("\n"));
                     }
                 }
             }
@@ -210,9 +210,9 @@
                 skipped = suite._skipped + suite._nestedSkipped,
                 disabled = suite._disabled + suite._nestedDisabled,
                 passed = total - failed - skipped,
-                color = failed ? 'red+bold' : 'green+bold',
-                str = passed + ' of ' + total + ' passed (' + skipped + ' skipped, ' + disabled + ' disabled)';
-            log(indentWithLevel(suite._depth, inColor(str+'.', color)));
+                color = failed ? "red+bold" : "green+bold",
+                str = passed + " of " + total + " passed (" + skipped + " skipped, " + disabled + " disabled)";
+            log(indentWithLevel(suite._depth, inColor(str+".", color)));
         };
         self.jasmineDone = function() {
             if (currentSuite) {
@@ -233,7 +233,7 @@
                 result_color = totalSpecsFailed && "red+bold" || "green+bold";
 
             if (self.verbosity === 2) {
-                log('');
+                log("");
             }
 
             if (self.verbosity > 0) {
@@ -253,7 +253,7 @@
         }
         function logStackLines(depth, lines) {
             lines.forEach(function(line){
-                log(inColor(indentWithLevel(depth, indent_string + line), 'magenta'));
+                log(inColor(indentWithLevel(depth, indent_string + line), "magenta"));
             });
         }
         function inColor(string, color) {


### PR DESCRIPTION
More comprehensive version of #154 

Configuration was created with `npm run lint -- --init` (plus minor tweaks like re-allowing `console.log`), and fixing violation was done with `npm run lint -- --fix` followed by very few minual fixes.
This will also be enforced by CI to make sure future PRs respect this.

This is how the config file was created:

<img width="537" alt="screen shot 2017-11-25 at 22 30 55" src="https://user-images.githubusercontent.com/113730/33237014-acbabeda-d234-11e7-96ee-7be4135b8f31.png">

The `.eslintrc.yml` file created is very minimal, I recommend going through https://eslint.org/docs/rules/ to see what is important to you after this PR.

⚠️ Note that some removals were the consequences of ESLint informing of a chain of unused variables. I tried my best but did not test this carefully beyond `npm test` so I might have removed test code that was supposed to stay.