### PR TITLE
Fix license field of `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,5 @@
   "devDependencies": {
     "jasmine": "^2.4.1"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/larrymyers/jasmine-reporters/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
When running `npm install`, the output would specify:

```
npm WARN jasmine-reporters@2.2.1 No license field.
```

According to [the docs](https://docs.npmjs.com/files/package.json#license):

> Some old packages used license objects or a "licenses" property containing an array of license objects: [...]
> Those styles are now deprecated. Instead, use SPDX expressions, like this: [...]