### PR TITLE
TAP Reporter Failure Message

### DIFF
--- a/src/tap_reporter.js
+++ b/src/tap_reporter.js
@@ -104,6 +104,7 @@
                         failedStr += '\n  === END STACK TRACE ===';
                     }
                 }
+                resultStr += failedStr;
             }
             if (isSkipped(spec)) {
                 totalSpecsSkipped++;


### PR DESCRIPTION
### Description

Fixes a bug where TAP reporter does not output error message nor stack trace.