### PR TITLE
Calculate jUnit total time in seconds

### DIFF
--- a/src/junit_reporter.js
+++ b/src/junit_reporter.js
@@ -504,7 +504,7 @@
                 prefix += '\n<?xml-stylesheet type="text/xsl" href="' + self.stylesheetPath + '" ?>';
             }
             prefix += '\n<testsuites disabled="' + results.disabled + '" errors="0" failures="' + results.failures +
-                '" tests="' + results.tests + '" time="' + results.time + '">';
+                '" tests="' + results.tests + '" time="' + results.time/1000 + '">';
             return prefix;
         }
         var suffix = "\n</testsuites>";


### PR DESCRIPTION
The jUnit total time is presented in milliseconds, whereas all suite times are presented in seconds (using the `elapsed` helper). This PR updates to convert the total time to seconds.