### PR TITLE
chore: Switch to new xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "xmldom": "^0.7.0"
+    "@xmldom/xmldom": "^0.7.3"
   },
   "devDependencies": {
     "eslint": "^4.11.0",

--- a/spec/JUnitXmlReporterSpec.js
+++ b/spec/JUnitXmlReporterSpec.js
@@ -1,6 +1,6 @@
 /* globals jasmine, describe, afterEach, beforeEach, it, expect */
 var jasmineReporters = require("../index");
-var DOMParser = require("xmldom").DOMParser;
+var DOMParser = require("@xmldom/xmldom").DOMParser;
 
 var env, suite,
     reporter, writeCalls, suiteId=0, specId=0, noop=function(){};

--- a/spec/NUnitXmlReporterSpec.js
+++ b/spec/NUnitXmlReporterSpec.js
@@ -1,6 +1,6 @@
 /* globals jasmine, describe, beforeEach, it, expect */
 var jasmineReporters = require("../index");
-var DOMParser = require("xmldom").DOMParser;
+var DOMParser = require("@xmldom/xmldom").DOMParser;
 
 var env, suite, subSuite, subSubSuite, siblingSuite,
     reporter, writeCalls, suiteId=0, specId=0, noop=function(){};


### PR DESCRIPTION
Old xmldom's maintainer is not reachable so xmldom is published to npm under the new name @xmldom/xmldom starting with version 0.7.0

This PR fixes #205

Ref: #203 